### PR TITLE
feat: Add check for meta/vaults/[network]

### DIFF
--- a/components/VaultBox.tsx
+++ b/components/VaultBox.tsx
@@ -40,7 +40,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 		|| !aggregatedData[toAddress(vault.address)]?.hasLedgerIntegration
 		|| !aggregatedData[toAddress(vault.address)]?.hasValidStrategiesDescriptions
 		|| !aggregatedData[toAddress(vault.address)]?.hasValidStrategiesRisk
-		|| !aggregatedData[toAddress(vault.address)]?.hasMissingYearnMetaFile
+		|| !aggregatedData[toAddress(vault.address)]?.hasYearnMetaFile
 	);
 
 	function	onTriggerModalForLedger(): void {

--- a/components/VaultBox.tsx
+++ b/components/VaultBox.tsx
@@ -181,7 +181,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				label={'Yearn Meta File'}
 				settings={settings}
 				anomalies={[{
-					isValid: aggregatedData[toAddress(vault.address)]?.hasMissingYearnMetaFile,
+					isValid: aggregatedData[toAddress(vault.address)]?.hasYearnMetaFile,
 					onClick: onTriggerModalForLedger,
 					prefix: 'Yearn Meta File',
 					sufix: 'for vault'

--- a/components/VaultBox.tsx
+++ b/components/VaultBox.tsx
@@ -150,8 +150,8 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				instructions: [
 					<span key={'step-1'}>
 						{'1. Access the vaults\' folder in the meta repo: '}
-						<a href={`https://github.com/yearn/yearn-meta/tree/master/data/vaults/${chainID}`} target={'_blank'} className={'underline'} rel={'noreferrer'}>
-							{`https://github.com/yearn/yearn-meta/tree/master/data/vaults/${chainID}`}
+						<a href={`https://github.com/yearn/ydaemon/tree/master/data/meta/vaults/${chainID}`} target={'_blank'} className={'underline'} rel={'noreferrer'}>
+							{`https://github.com/yearn/ydaemon/tree/master/data/meta/vaults/${chainID}`}
 						</a>
 					</span>,
 					<span key={'step-3'}>

--- a/components/VaultBox.tsx
+++ b/components/VaultBox.tsx
@@ -140,6 +140,33 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 		});
 	}
 
+	function	onTriggerModalForMetaFileMissing(): void {
+		set_fixModalData({
+			isOpen: true,
+			fix: {
+				category: 'file',
+				address: vault.address,
+				name: vault.name,
+				instructions: [
+					<span key={'step-1'}>
+						{'1. Access the vaults\' folder in the meta repo: '}
+						<a href={`https://github.com/yearn/yearn-meta/tree/master/data/vaults/${chainID}`} target={'_blank'} className={'underline'} rel={'noreferrer'}>
+							{`https://github.com/yearn/yearn-meta/tree/master/data/vaults/${chainID}`}
+						</a>
+					</span>,
+					<span key={'step-3'}>
+						{'2. Add missing vault file with the filename '}
+						<code
+							onClick={(): void => copyToClipboard(`${vault.address}.json`)}
+							className={'cursor-copy rounded-md bg-neutral-200 py-1 px-2 text-sm'}>
+							{`${vault.address}.json`}
+						</code>
+					</span>
+				]
+			}
+		});
+	}
+
 	if (!hasAnomalies && settings.shouldShowOnlyAnomalies) {
 		return null;
 	}
@@ -182,7 +209,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				settings={settings}
 				anomalies={[{
 					isValid: aggregatedData[toAddress(vault.address)]?.hasYearnMetaFile,
-					onClick: onTriggerModalForLedger,
+					onClick: onTriggerModalForMetaFileMissing,
 					prefix: 'Yearn Meta File',
 					sufix: 'for vault'
 				}]} />

--- a/components/VaultBox.tsx
+++ b/components/VaultBox.tsx
@@ -40,6 +40,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 		|| !aggregatedData[toAddress(vault.address)]?.hasLedgerIntegration
 		|| !aggregatedData[toAddress(vault.address)]?.hasValidStrategiesDescriptions
 		|| !aggregatedData[toAddress(vault.address)]?.hasValidStrategiesRisk
+		|| !aggregatedData[toAddress(vault.address)]?.hasMissingYearnMetaFile
 	);
 
 	function	onTriggerModalForLedger(): void {
@@ -175,6 +176,16 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 					</div>
 				</div>
 			</div>
+
+			<AnomaliesSection
+				label={'Yearn Meta File'}
+				settings={settings}
+				anomalies={[{
+					isValid: aggregatedData[toAddress(vault.address)]?.hasMissingYearnMetaFile,
+					onClick: onTriggerModalForLedger,
+					prefix: 'Yearn Meta File',
+					sufix: 'for vault'
+				}]} />
 
 			<AnomaliesSection
 				label={'Icon'}

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -98,7 +98,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasValidStrategiesRisk,
 					hasValidIcon: true,
 					hasValidTokenIcon: true,
-					hasYearnMetaFile: hasYearnMetaFile,
+					hasYearnMetaFile,
 					missingTranslations: missingTranslations,
 					address: toAddress(data.address),
 					name: data.display_name || data.name,

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -19,7 +19,7 @@ type	TAllData = {
 		hasValidStrategiesRisk: boolean,
 		hasValidIcon: boolean,
 		hasValidTokenIcon: boolean,
-		hasMissingYearnMetaFile: boolean;
+		hasYearnMetaFile: boolean;
 		missingTranslations: {[key: string]: string[]},
 		address: string,
 		name: string,
@@ -87,7 +87,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					return hasRiskFramework;
 				});
 
-				const	hasMissingYearnMetaFile = YEARN_META_FILES.filter((f): boolean => f !== '0xa258C4606Ca8206D8aA700cE2143D7db854D168c').includes(data.address);
+				const	hasYearnMetaFile = YEARN_META_FILES.includes(data.address);
 
 				const missingTranslations: {[key: string]: string[]} = {};
 
@@ -98,7 +98,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasValidStrategiesRisk,
 					hasValidIcon: true,
 					hasValidTokenIcon: true,
-					hasMissingYearnMetaFile,
+					hasYearnMetaFile: hasYearnMetaFile,
 					missingTranslations: missingTranslations,
 					address: toAddress(data.address),
 					name: data.display_name || data.name,
@@ -110,7 +110,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 
 		for (const data of _ledgerSupport?.data?.contracts || []) {
 			if (!_allData[toAddress(data.address) as string]) {
-				const	hasMissingYearnMetaFile = YEARN_META_FILES.includes(data.address);
+				const	hasYearnMetaFile = YEARN_META_FILES.includes(data.address);
 
 				_allData[toAddress(data.address) as string] = {
 					hasLedgerIntegration: true,
@@ -119,7 +119,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasValidStrategiesRisk: false,
 					hasValidIcon: false,
 					hasValidTokenIcon: false,
-					hasMissingYearnMetaFile,
+					hasYearnMetaFile,
 					missingTranslations: {},
 					address: toAddress(data.address),
 					name: data?.contractName || '',

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -1,5 +1,5 @@
 import	React, {ReactElement, useContext, createContext}	from	'react';
-import	axios												from	'axios';
+import	axios, {AxiosResponse}								from	'axios';
 import	{performBatchedUpdates, toAddress}					from	'@yearn-finance/web-lib/utils';
 import	{useWeb3}											from	'@yearn-finance/web-lib/contexts';
 
@@ -19,12 +19,17 @@ type	TAllData = {
 		hasValidStrategiesRisk: boolean,
 		hasValidIcon: boolean,
 		hasValidTokenIcon: boolean,
+		hasMissingYearnMetaFile: boolean;
 		missingTranslations: {[key: string]: string[]},
 		address: string,
 		name: string,
 		icon: string,
 		version: string
 	}
+}
+
+type	TGHFile = {
+	name: string
 }
 
 const	YearnContext = createContext<TYearnContext>({
@@ -50,11 +55,14 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 	** anomalies.
 	**********************************************************************/
 	const getYearnDataSync = React.useCallback(async (_chainID: number): Promise<void> => {
-		const	[fromAPI, _ledgerSupport, _riskFramework] = await Promise.all([
+		const	[fromAPI, _ledgerSupport, _riskFramework, _metaFiles] = await Promise.all([
 			axios.get(`https://ydaemon.yearn.finance/${_chainID}/vaults/all?classification=any&strategiesRisk=withRisk`),
 			axios.get('https://raw.githubusercontent.com/LedgerHQ/app-plugin-yearn/develop/tests/yearn/b2c.json'),
-			axios.get('https://raw.githubusercontent.com/yearn/yearn-data-analytics/master/src/risk_framework/risks.json')
-		]) as [any, any, any];
+			axios.get('https://raw.githubusercontent.com/yearn/yearn-data-analytics/master/src/risk_framework/risks.json'),
+			axios.get(`https://api.github.com/repos/yearn/yearn-meta/contents/data/vaults/${_chainID}`)
+		]) as [any, any, any, AxiosResponse<TGHFile[]>];
+
+		const YEARN_META_FILES = _metaFiles.data.map((meta): string => toAddress(meta.name.split('.')[0]));
 
 		const	_allData: TAllData = {};
 		for (const data of fromAPI.data) {
@@ -79,6 +87,8 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					return hasRiskFramework;
 				});
 
+				const	hasMissingYearnMetaFile = YEARN_META_FILES.includes(data.address);
+
 				const missingTranslations: {[key: string]: string[]} = {};
 
 				_allData[toAddress(data.address) as string] = {
@@ -88,6 +98,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasValidStrategiesRisk,
 					hasValidIcon: true,
 					hasValidTokenIcon: true,
+					hasMissingYearnMetaFile,
 					missingTranslations: missingTranslations,
 					address: toAddress(data.address),
 					name: data.display_name || data.name,

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -59,7 +59,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 			axios.get(`https://ydaemon.yearn.finance/${_chainID}/vaults/all?classification=any&strategiesRisk=withRisk`),
 			axios.get('https://raw.githubusercontent.com/LedgerHQ/app-plugin-yearn/develop/tests/yearn/b2c.json'),
 			axios.get('https://raw.githubusercontent.com/yearn/yearn-data-analytics/master/src/risk_framework/risks.json'),
-			axios.get(`https://api.github.com/repos/yearn/yearn-meta/contents/data/vaults/${_chainID}`)
+			axios.get(`https://api.github.com/repos/yearn/ydaemon/contents/data/meta/vaults/${_chainID}`)
 		]) as [any, any, any, AxiosResponse<TGHFile[]>];
 
 		const YEARN_META_FILES = _metaFiles.data.map((meta): string => toAddress(meta.name.split('.')[0]));

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -87,7 +87,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					return hasRiskFramework;
 				});
 
-				const	hasMissingYearnMetaFile = YEARN_META_FILES.includes(data.address);
+				const	hasMissingYearnMetaFile = YEARN_META_FILES.filter((f): boolean => f !== '0xa258C4606Ca8206D8aA700cE2143D7db854D168c').includes(data.address);
 
 				const missingTranslations: {[key: string]: string[]} = {};
 
@@ -110,6 +110,8 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 
 		for (const data of _ledgerSupport?.data?.contracts || []) {
 			if (!_allData[toAddress(data.address) as string]) {
+				const	hasMissingYearnMetaFile = YEARN_META_FILES.includes(data.address);
+
 				_allData[toAddress(data.address) as string] = {
 					hasLedgerIntegration: true,
 					hasValidStrategiesDescriptions: false,
@@ -117,6 +119,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasValidStrategiesRisk: false,
 					hasValidIcon: false,
 					hasValidTokenIcon: false,
+					hasMissingYearnMetaFile,
 					missingTranslations: {},
 					address: toAddress(data.address),
 					name: data?.contractName || '',

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -9,7 +9,7 @@ export type	TAnomalies = {
 export type	TFixModalData = {
 	isOpen: boolean,
 	fix: {
-		category: 'ledger' | 'description' | '',
+		category: 'ledger' | 'description' | 'file' | '',
 		address: string,
 		name: string,
 		instructions: (string | ReactElement)[]


### PR DESCRIPTION
## Description

For each vault:
* Check if a file matching the vault address exists in `yearn-meta/vaults/[chainId]` and display an error if it does not.
* Add a modal explaining how to add the missing file;

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/40

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We'd like to be warned when a vault does not have a corresponding file on https://github.com/yearn/yearn-meta/tree/master/data/vaults

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Manually filtered an existing file from the GitHub file list and saw the error being displayed

## Screenshots (if appropriate):

<img width="637" alt="ySync" src="https://user-images.githubusercontent.com/78794805/187805360-47d8fe6d-5d77-4d3f-a2d1-7532539a53d5.png">


<img width="1251" alt="ySync" src="https://user-images.githubusercontent.com/78794805/187807494-070420b6-4d8f-420c-a2d9-7e05b3e0f91a.png">
