### PR TITLE
feat: Add detection of missing strategies translations

### DIFF
--- a/components/VaultBox.tsx
+++ b/components/VaultBox.tsx
@@ -299,6 +299,32 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				</section>
 			)}
 
+			{Object.keys(aggregatedData[toAddress(vault.address)]?.missingTranslations).length !== 0 && settings.shouldShowMissingTranslations ? (
+				<section aria-label={'strategies check'} className={'mt-3 flex flex-col pl-0 md:pl-14'}>
+					<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Missing Translations'}</b>
+					{Object.keys(aggregatedData[toAddress(vault.address)]?.missingTranslations).map((strategyAddress: any): ReactNode => {
+						const missingTranslation = aggregatedData[toAddress(vault.address)]?.missingTranslations;
+						const shortAddress = `${strategyAddress.substr(0, 8)}...${strategyAddress.substr(strategyAddress.length-8, strategyAddress.length)}`; 
+
+						return (
+							<StatusLine
+								key={`${strategyAddress}_translation`}
+								settings={settings}
+								isValid={false}
+								prefix={missingTranslation[strategyAddress].join(', ')}
+								sufix={(
+									<span>
+										{'for '}
+										<a href={`${getChainExplorer()}/address/${strategyAddress}`} className={'text-red-900 underline'} rel={'noreferrer'}>
+											{shortAddress}
+										</a>
+									</span>
+								)} />
+						);
+					})}
+				</section>
+			) : null}
+
 			<ModalFix
 				fix={fixModalData.fix}
 				isOpen={fixModalData.isOpen}

--- a/components/VaultBox.tsx
+++ b/components/VaultBox.tsx
@@ -247,7 +247,6 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 						sufix={''} />
 				</section> : null}
 
-
 			{aggregatedData[toAddress(vault.address)]?.hasValidStrategiesRisk && settings.shouldShowOnlyAnomalies ? null : (
 				<section aria-label={'strategies check'} className={'mt-3 flex flex-col pl-0 md:pl-14'}>
 					<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Risk Score'}</b>
@@ -299,7 +298,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				</section>
 			)}
 
-			{Object.keys(aggregatedData[toAddress(vault.address)]?.missingTranslations).length !== 0 && settings.shouldShowMissingTranslations ? (
+			{Object.keys((aggregatedData?.[toAddress(vault.address)]?.missingTranslations) || []).length !== 0 && settings.shouldShowMissingTranslations ? (
 				<section aria-label={'strategies check'} className={'mt-3 flex flex-col pl-0 md:pl-14'}>
 					<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Missing Translations'}</b>
 					{Object.keys(aggregatedData[toAddress(vault.address)]?.missingTranslations).map((strategyAddress: any): ReactNode => {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,8 @@ import	type {TSettings}			from	'types/types';
 const	defaultSettings: TSettings = {
 	shouldShowOnlyAnomalies: true,
 	shouldShowOnlyEndorsed: true,
-	shouldShowVersion: 'v4'
+	shouldShowVersion: 'v4',
+	shouldShowMissingTranslations: false
 };
 
 function	Index(): ReactNode {
@@ -87,6 +88,18 @@ function	Index(): ReactNode {
 								className={'ml-2 rounded-lg'}
 								checked={settings.shouldShowOnlyAnomalies}
 								onChange={(): void => set_settings({...settings, shouldShowOnlyAnomalies: !settings.shouldShowOnlyAnomalies})} />
+						</label>
+
+						<label
+							htmlFor={'checkbox-translations'}
+							className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
+							<p className={'pr-4'}>{'Show missing translations'}</p>
+							<input
+								type={'checkbox'}
+								id={'checkbox-translations'}
+								className={'ml-2 rounded-lg'}
+								checked={settings.shouldShowMissingTranslations}
+								onChange={(): void => set_settings({...settings, shouldShowMissingTranslations: !settings.shouldShowMissingTranslations})} />
 						</label>
 
 						<span

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -25,4 +25,5 @@ export type TSettings = {
 	shouldShowOnlyAnomalies: boolean;
 	shouldShowOnlyEndorsed: boolean;
 	shouldShowVersion: 'all' | 'v2' | 'v3' | 'v4';
+	shouldShowMissingTranslations: boolean;
 }


### PR DESCRIPTION
## Description

For each strategy of each vault check if there are any translations missing

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/48

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We'd like to be warned  of missing strategies' translations

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and saw the missing translations being displayed, refer to screenshot below

## Screenshots (if appropriate):

<img width="1238" alt="ySync" src="https://user-images.githubusercontent.com/78794805/188114324-e05feeb3-79b7-4edf-ae0b-5bd1f80e8979.png">
