### PR TITLE
feat: Add detection of missing token translations

### DIFF
--- a/components/TranslationStatusLine.tsx
+++ b/components/TranslationStatusLine.tsx
@@ -1,0 +1,42 @@
+import	React, {ReactElement}				from	'react';
+import	IconCross							from	'components/icons/IconCross';
+import	IconCheck							from	'components/icons/IconCheck';
+
+
+function	TranslationStatusLine({
+	isValid,
+	content
+}: {isValid: boolean, content: string}): ReactElement {
+	if (isValid) {
+		return (
+			<div className={'flex flex-row items-start space-x-2'}>
+				<IconCheck className={'mt-[2px] h-4 min-h-[16px] w-4 min-w-[16px] text-accent-500'}/>
+				<p className={'break-all text-sm text-neutral-500'}>
+					{content}
+				</p>
+			</div>
+		);
+	}
+
+	if (isValid === null) { //indeterminate state
+		return (
+			<div className={'flex flex-row items-start space-x-2'}>
+				<div className={'mt-[2px] h-4 min-h-[16px] w-4 min-w-[16px] rounded-full bg-neutral-400'} />
+				<p className={'text-sm text-neutral-500'}>
+					{'Checking ...'}
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className={'flex flex-row items-start space-x-2'}>
+			<IconCross className={'mt-[2px] h-4 min-h-[16px] w-4 min-w-[16px] text-red-900'}/>
+			<p className={'break-all text-sm text-neutral-500'}>
+				{content}
+			</p>
+		</div>
+	);
+}
+
+export default TranslationStatusLine;

--- a/components/VaultBox.tsx
+++ b/components/VaultBox.tsx
@@ -7,7 +7,8 @@ import	useYearn 							from	'contexts/useYearn';
 import	AnomaliesSection					from	'components/VaultBox.AnomaliesSection';
 import	StatusLine							from	'components/VaultBox.StatusLine';
 import	ModalFix							from	'components/modals/ModalFix';
-import	type {TFixModalData, TSettings}		from 'types/types';
+import	type {TFixModalData, TSettings}		from 	'types/types';
+import {getChainExplorer} 					from 	'components/utils/getChainExplorer';
 
 const		defaultFixModalData: TFixModalData = {
 	isOpen: false,
@@ -24,23 +25,14 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 	const	{chainID} = useWeb3();
 	const	[fixModalData, set_fixModalData] = React.useState<TFixModalData>(defaultFixModalData);
 
-	function	getChainExplorer(): string {
-		if (chainID === 250) {
-			return ('https://ftmscan.com');
-		} else if (chainID === 42161) {
-			return ('https://arbiscan.io');
-		} 
-		return ('https://etherscan.io');
-	}
-
 	const		hasAnomalies = (
 		vault.strategies.length === 0
-		|| !aggregatedData[toAddress(vault.address)]?.hasValidIcon
-		|| !aggregatedData[toAddress(vault.address)]?.hasValidTokenIcon
-		|| !aggregatedData[toAddress(vault.address)]?.hasLedgerIntegration
-		|| !aggregatedData[toAddress(vault.address)]?.hasValidStrategiesDescriptions
-		|| !aggregatedData[toAddress(vault.address)]?.hasValidStrategiesRisk
-		|| !aggregatedData[toAddress(vault.address)]?.hasYearnMetaFile
+		|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidIcon
+		|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidTokenIcon
+		|| !aggregatedData.vaults[toAddress(vault.address)]?.hasLedgerIntegration
+		|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidStrategiesDescriptions
+		|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidStrategiesRisk
+		|| !aggregatedData.vaults[toAddress(vault.address)]?.hasYearnMetaFile
 	);
 
 	function	onTriggerModalForLedger(): void {
@@ -208,7 +200,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				label={'Yearn Meta File'}
 				settings={settings}
 				anomalies={[{
-					isValid: aggregatedData[toAddress(vault.address)]?.hasYearnMetaFile,
+					isValid: aggregatedData.vaults[toAddress(vault.address)]?.hasYearnMetaFile,
 					onClick: onTriggerModalForMetaFileMissing,
 					prefix: 'Yearn Meta File',
 					sufix: 'for vault'
@@ -218,11 +210,11 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				label={'Icon'}
 				settings={settings}
 				anomalies={[{
-					isValid: aggregatedData[toAddress(vault.address)]?.hasValidIcon,
+					isValid: aggregatedData.vaults[toAddress(vault.address)]?.hasValidIcon,
 					prefix: 'Icon',
 					sufix: 'for vault'
 				}, {
-					isValid: aggregatedData[toAddress(vault.address)]?.hasValidTokenIcon,
+					isValid: aggregatedData.vaults[toAddress(vault.address)]?.hasValidTokenIcon,
 					prefix: 'Icon',
 					sufix: 'for underlying token'
 				}]} />
@@ -231,7 +223,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				label={'Ledger Live'}
 				settings={settings}
 				anomalies={[{
-					isValid: aggregatedData[toAddress(vault.address)]?.hasLedgerIntegration,
+					isValid: aggregatedData.vaults[toAddress(vault.address)]?.hasLedgerIntegration,
 					onClick: onTriggerModalForLedger,
 					prefix: 'Ledger integration',
 					sufix: 'for vault'
@@ -247,7 +239,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 						sufix={''} />
 				</section> : null}
 
-			{aggregatedData[toAddress(vault.address)]?.hasValidStrategiesRisk && settings.shouldShowOnlyAnomalies ? null : (
+			{aggregatedData.vaults[toAddress(vault.address)]?.hasValidStrategiesRisk && settings.shouldShowOnlyAnomalies ? null : (
 				<section aria-label={'strategies check'} className={'mt-3 flex flex-col pl-0 md:pl-14'}>
 					<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Risk Score'}</b>
 					{vault.strategies.map((strategy: any): ReactNode => {
@@ -261,7 +253,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 								sufix={(
 									<span>
 										{'for strategy '}
-										<a href={`${getChainExplorer()}/address/${strategy.address}`} target={'_blank'} className={`underline ${hasRiskFramework ? '' : 'text-red-900'}`} rel={'noreferrer'}>
+										<a href={`${getChainExplorer(chainID)}/address/${strategy.address}`} target={'_blank'} className={`underline ${hasRiskFramework ? '' : 'text-red-900'}`} rel={'noreferrer'}>
 											{strategy.name}
 										</a>
 									</span>
@@ -272,7 +264,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				</section>
 			)}
 
-			{aggregatedData[toAddress(vault.address)]?.hasValidStrategiesDescriptions && settings.shouldShowOnlyAnomalies ? null : (
+			{aggregatedData.vaults[toAddress(vault.address)]?.hasValidStrategiesDescriptions && settings.shouldShowOnlyAnomalies ? null : (
 				<section aria-label={'strategies check'} className={'mt-3 flex flex-col pl-0 md:pl-14'}>
 					<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Descriptions'}</b>
 					{vault.strategies.map((strategy: any): ReactNode => {
@@ -288,7 +280,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 								sufix={(
 									<span>
 										{'for strategy '}
-										<a href={`${getChainExplorer()}/address/${strategy.address}`} target={'_blank'} className={`underline ${!isMissingDescription ? '' : 'text-red-900'}`} rel={'noreferrer'}>
+										<a href={`${getChainExplorer(chainID)}/address/${strategy.address}`} target={'_blank'} className={`underline ${!isMissingDescription ? '' : 'text-red-900'}`} rel={'noreferrer'}>
 											{strategy.name}
 										</a>
 									</span>
@@ -298,11 +290,11 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 				</section>
 			)}
 
-			{Object.keys((aggregatedData?.[toAddress(vault.address)]?.missingTranslations) || []).length !== 0 && settings.shouldShowMissingTranslations ? (
+			{Object.keys((aggregatedData?.vaults[toAddress(vault.address)]?.missingTranslations) || []).length !== 0 && settings.shouldShowMissingTranslations ? (
 				<section aria-label={'strategies check'} className={'mt-3 flex flex-col pl-0 md:pl-14'}>
 					<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Missing Translations'}</b>
-					{Object.keys(aggregatedData[toAddress(vault.address)]?.missingTranslations).map((strategyAddress: any): ReactNode => {
-						const missingTranslation = aggregatedData[toAddress(vault.address)]?.missingTranslations;
+					{Object.keys(aggregatedData.vaults[toAddress(vault.address)]?.missingTranslations).map((strategyAddress: any): ReactNode => {
+						const missingTranslation = aggregatedData.vaults[toAddress(vault.address)]?.missingTranslations;
 						const shortAddress = `${strategyAddress.substr(0, 8)}...${strategyAddress.substr(strategyAddress.length-8, strategyAddress.length)}`; 
 
 						return (
@@ -314,7 +306,7 @@ function	VaultBox({vault, settings, noStrategies}: {vault: any, settings: TSetti
 								sufix={(
 									<span>
 										{'for '}
-										<a href={`${getChainExplorer()}/address/${strategyAddress}`} className={'text-red-900 underline'} rel={'noreferrer'}>
+										<a href={`${getChainExplorer(chainID)}/address/${strategyAddress}`} className={'text-red-900 underline'} rel={'noreferrer'}>
 											{shortAddress}
 										</a>
 									</span>

--- a/components/utils/getChainExplorer.ts
+++ b/components/utils/getChainExplorer.ts
@@ -1,0 +1,11 @@
+export function	getChainExplorer({chainID}: {chainID: number}): string {
+	if (chainID === 250) {
+		return ('https://ftmscan.com');
+	}
+	
+	if (chainID === 42161) {
+		return ('https://arbiscan.io');
+	} 
+	
+	return ('https://etherscan.io');
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,50 +1,67 @@
 import	React, {ReactNode}			from	'react';
 import	{useWeb3}					from	'@yearn-finance/web-lib/contexts';
 import	{toAddress}					from	'@yearn-finance/web-lib/utils';
-import	{Card, StatisticCard}		from	'@yearn-finance/web-lib/components';
+import	{AddressWithActions, Card, StatisticCard, Dropdown}		from	'@yearn-finance/web-lib/components';
 import	useYearn 					from	'contexts/useYearn';
 import	VaultBox					from	'components/VaultBox';
 import	ImageTester					from	'components/ImageTester';
 import	type {TSettings}			from	'types/types';
+import TranslationStatusLine 		from 'components/TranslationStatusLine';
 
 const	defaultSettings: TSettings = {
 	shouldShowOnlyAnomalies: true,
 	shouldShowOnlyEndorsed: true,
 	shouldShowVersion: 'v4',
-	shouldShowMissingTranslations: false
+	shouldShowMissingTranslations: false,
+	shouldShowEntity: 'vaults'
 };
+
+type 	TOption = {label: string; value: 'vaults' | 'tokens'};
+
+const	OPTIONS: TOption[] = [
+	{label: 'Vaults', value: 'vaults'},
+	{label: 'Tokens', value: 'tokens'}
+];
 
 function	Index(): ReactNode {
 	const	{chainID} = useWeb3();
 	const	{dataFromAPI, aggregatedData} = useYearn();
 	const	[vaults, set_vaults] = React.useState<any[]>([]);
+	const	[tokens, set_tokens] = React.useState<any>();
 	const	[settings, set_settings] = React.useState<TSettings>(defaultSettings);
+	const	[selectedOption, set_selectedOption] = React.useState(OPTIONS[0]);
 
 	React.useEffect((): void => {
-		let	_vaults = [...dataFromAPI];
-		if (settings.shouldShowOnlyEndorsed) {
-			_vaults = _vaults.filter((vault: {endorsed: boolean}): boolean => vault.endorsed);
+		if (settings.shouldShowEntity === 'vaults') {
+			let	_vaults = [...dataFromAPI];
+			if (settings.shouldShowOnlyEndorsed) {
+				_vaults = _vaults.filter((vault: {endorsed: boolean}): boolean => vault.endorsed);
+			}
+
+			if (settings.shouldShowVersion === 'v2') {
+				_vaults = _vaults.filter((vault: {version: string}): boolean => Number(vault.version.replace('.', '')) >= 2);
+			} else if (settings.shouldShowVersion === 'v3') {
+				_vaults = _vaults.filter((vault: {version: string}): boolean => Number(vault.version.replace('.', '')) >= 3);
+			} else if (settings.shouldShowVersion === 'v4') {
+				_vaults = _vaults.filter((vault: {version: string}): boolean => Number(vault.version.replace('.', '')) >= 4);
+			}
+			set_vaults(_vaults);
 		}
 
-		if (settings.shouldShowVersion === 'v2') {
-			_vaults = _vaults.filter((vault: {version: string}): boolean => Number(vault.version.replace('.', '')) >= 2);
-		} else if (settings.shouldShowVersion === 'v3') {
-			_vaults = _vaults.filter((vault: {version: string}): boolean => Number(vault.version.replace('.', '')) >= 3);
-		} else if (settings.shouldShowVersion === 'v4') {
-			_vaults = _vaults.filter((vault: {version: string}): boolean => Number(vault.version.replace('.', '')) >= 4);
+		if (settings.shouldShowEntity === 'tokens') {
+			set_tokens(aggregatedData.tokens);
 		}
-		set_vaults(_vaults);
-	}, [dataFromAPI, settings, chainID]);
+	}, [dataFromAPI, settings, chainID, aggregatedData.tokens]);
 
 	const	errorCount = React.useMemo((): number => (
 		vaults
 			.filter((vault): boolean => {
 				const	hasAnomalies = (
 					vault.strategies.length === 0
-					|| !aggregatedData[toAddress(vault.address)]?.hasValidIcon
-					|| !aggregatedData[toAddress(vault.address)]?.hasLedgerIntegration
-					|| !aggregatedData[toAddress(vault.address)]?.hasValidStrategiesDescriptions
-					|| !aggregatedData[toAddress(vault.address)]?.hasValidStrategiesRisk
+					|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidIcon
+					|| !aggregatedData.vaults[toAddress(vault.address)]?.hasLedgerIntegration
+					|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidStrategiesDescriptions
+					|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidStrategiesRisk
 				);
 				return (hasAnomalies);
 			})
@@ -66,94 +83,104 @@ function	Index(): ReactNode {
 				<div className={'flex flex-col space-y-2 pb-6'}>
 					<b className={'text-lg'}>{'Filters'}</b>
 					<div className={'grid grid-cols-2 flex-row gap-4 space-x-0 md:flex md:gap-0 md:space-x-4'}>
-						<label
-							htmlFor={'checkbox-endorsed'}
-							className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
-							<p className={'pr-4'}>{'Show endorsed only'}</p>
-							<input
-								type={'checkbox'}
-								id={'checkbox-endorsed'}
-								className={'ml-2 rounded-lg'}
-								checked={settings.shouldShowOnlyEndorsed}
-								onChange={(): void => set_settings({...settings, shouldShowOnlyEndorsed: !settings.shouldShowOnlyEndorsed})} />
-						</label>
-
-						<label
-							htmlFor={'checkbox-anomalies'}
-							className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
-							<p className={'pr-4'}>{'Show anomalies only'}</p>
-							<input
-								type={'checkbox'}
-								id={'checkbox-anomalies'}
-								className={'ml-2 rounded-lg'}
-								checked={settings.shouldShowOnlyAnomalies}
-								onChange={(): void => set_settings({...settings, shouldShowOnlyAnomalies: !settings.shouldShowOnlyAnomalies})} />
-						</label>
-
-						<label
-							htmlFor={'checkbox-translations'}
-							className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
-							<p className={'pr-4'}>{'Show missing translations'}</p>
-							<input
-								type={'checkbox'}
-								id={'checkbox-translations'}
-								className={'ml-2 rounded-lg'}
-								checked={settings.shouldShowMissingTranslations}
-								onChange={(): void => set_settings({...settings, shouldShowMissingTranslations: !settings.shouldShowMissingTranslations})} />
-						</label>
-
-						<span
-							className={'col-span-2 flex w-full flex-row items-center overflow-hidden rounded-lg bg-neutral-200/60 font-mono text-sm text-neutral-500 transition-colors md:w-fit'}>
-							<p className={'pr-4 pl-2'}>{'Version'}</p>
-
-							<div className={'divide-primary flex flex-row'}>
-								<label className={'cursor-pointer p-2 transition-colors hover:bg-neutral-200'} htmlFor={'checkbox-vaults-all'}>
-									{'All'}
+						<Dropdown
+							defaultOption={OPTIONS[0]}
+							options={OPTIONS}
+							selected={selectedOption}
+							onSelect={(option: TOption): void => {
+								set_selectedOption(option);
+								set_settings({...settings, shouldShowEntity: option.value});
+							}} />
+						{settings.shouldShowEntity === 'vaults' && (
+							<>
+								<label
+									htmlFor={'checkbox-endorsed'}
+									className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
+									<p className={'pr-4'}>{'Show endorsed only'}</p>
 									<input
 										type={'checkbox'}
-										id={'checkbox-vaults-all'}
+										id={'checkbox-endorsed'}
 										className={'ml-2 rounded-lg'}
-										checked={settings.shouldShowVersion === 'all'}
-										onChange={(): void => set_settings({...settings, shouldShowVersion: 'all'})} />
+										checked={settings.shouldShowOnlyEndorsed}
+										onChange={(): void => set_settings({...settings, shouldShowOnlyEndorsed: !settings.shouldShowOnlyEndorsed})} />
 								</label>
-
-								<label className={'cursor-pointer p-2 transition-colors hover:bg-neutral-200'} htmlFor={'checkbox-vaults-v2'}>
-									{'>= v0.2.0'}
+								<label
+									htmlFor={'checkbox-anomalies'}
+									className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
+									<p className={'pr-4'}>{'Show anomalies only'}</p>
 									<input
 										type={'checkbox'}
-										id={'checkbox-vaults-v2'}
+										id={'checkbox-anomalies'}
 										className={'ml-2 rounded-lg'}
-										checked={settings.shouldShowVersion === 'v2'}
-										onChange={(): void => set_settings({...settings, shouldShowVersion: 'v2'})} />
+										checked={settings.shouldShowOnlyAnomalies}
+										onChange={(): void => set_settings({...settings, shouldShowOnlyAnomalies: !settings.shouldShowOnlyAnomalies})} />
 								</label>
-
-								<label className={'cursor-pointer p-2 transition-colors hover:bg-neutral-200'} htmlFor={'checkbox-vaults-v3'}>
-									{'>= v0.3.0'}
+								<label
+									htmlFor={'checkbox-translations'}
+									className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
+									<p className={'pr-4'}>{'Show missing translations'}</p>
 									<input
 										type={'checkbox'}
-										id={'checkbox-vaults-v3'}
+										id={'checkbox-translations'}
 										className={'ml-2 rounded-lg'}
-										checked={settings.shouldShowVersion === 'v3'}
-										onChange={(): void => set_settings({...settings, shouldShowVersion: 'v3'})} />
+										checked={settings.shouldShowMissingTranslations}
+										onChange={(): void => set_settings({...settings, shouldShowMissingTranslations: !settings.shouldShowMissingTranslations})} />
 								</label>
+								<span
+									className={'col-span-2 flex w-full flex-row items-center overflow-hidden rounded-lg bg-neutral-200/60 font-mono text-sm text-neutral-500 transition-colors md:w-fit'}>
+									<p className={'pr-4 pl-2'}>{'Version'}</p>
 
-								<label className={'cursor-pointer p-2 transition-colors hover:bg-neutral-200'} htmlFor={'checkbox-vaults-v4'}>
-									{'>= v0.4.0'}
-									<input
-										type={'checkbox'}
-										id={'checkbox-vaults-v4'}
-										className={'ml-2 rounded-lg'}
-										checked={settings.shouldShowVersion === 'v4'}
-										onChange={(): void => set_settings({...settings, shouldShowVersion: 'v4'})} />
-								</label>
-							</div>
-						</span>
+									<div className={'divide-primary flex flex-row'}>
+										<label className={'cursor-pointer p-2 transition-colors hover:bg-neutral-200'} htmlFor={'checkbox-vaults-all'}>
+											{'All'}
+											<input
+												type={'checkbox'}
+												id={'checkbox-vaults-all'}
+												className={'ml-2 rounded-lg'}
+												checked={settings.shouldShowVersion === 'all'}
+												onChange={(): void => set_settings({...settings, shouldShowVersion: 'all'})} />
+										</label>
+
+										<label className={'cursor-pointer p-2 transition-colors hover:bg-neutral-200'} htmlFor={'checkbox-vaults-v2'}>
+											{'>= v0.2.0'}
+											<input
+												type={'checkbox'}
+												id={'checkbox-vaults-v2'}
+												className={'ml-2 rounded-lg'}
+												checked={settings.shouldShowVersion === 'v2'}
+												onChange={(): void => set_settings({...settings, shouldShowVersion: 'v2'})} />
+										</label>
+
+										<label className={'cursor-pointer p-2 transition-colors hover:bg-neutral-200'} htmlFor={'checkbox-vaults-v3'}>
+											{'>= v0.3.0'}
+											<input
+												type={'checkbox'}
+												id={'checkbox-vaults-v3'}
+												className={'ml-2 rounded-lg'}
+												checked={settings.shouldShowVersion === 'v3'}
+												onChange={(): void => set_settings({...settings, shouldShowVersion: 'v3'})} />
+										</label>
+
+										<label className={'cursor-pointer p-2 transition-colors hover:bg-neutral-200'} htmlFor={'checkbox-vaults-v4'}>
+											{'>= v0.4.0'}
+											<input
+												type={'checkbox'}
+												id={'checkbox-vaults-v4'}
+												className={'ml-2 rounded-lg'}
+												checked={settings.shouldShowVersion === 'v4'}
+												onChange={(): void => set_settings({...settings, shouldShowVersion: 'v4'})} />
+										</label>
+									</div>
+								</span>
+							</>
+						)}
+
 					</div>
 				</div>
 				<div className={'flex flex-col space-y-2 pb-6'}>
 					<b className={'text-lg'}>{'Results'}</b>
 					<div className={'mt-4 grid w-full grid-cols-1 gap-4 md:grid-cols-2'}>
-						{vaults.map((vault: any, index: number): ReactNode => {
+						{settings.shouldShowEntity === 'vaults' && vaults.map((vault: any, index: number): ReactNode => {
 							if (vault.strategies.length === 0) {
 								return (
 									<VaultBox key={`${vault.address}_${index}`} vault={vault} settings={settings} noStrategies />
@@ -163,6 +190,47 @@ function	Index(): ReactNode {
 								<VaultBox key={`${vault.address}_${index}`} vault={vault} settings={settings} />
 							);
 						})}
+
+						{settings.shouldShowEntity === 'tokens' && tokens && Object.keys(tokens).map((tokenAddress: string): ReactNode => {
+							const {name, symbol, missingTranslations} = aggregatedData.tokens[toAddress(tokenAddress)];
+
+							if (!missingTranslations) {
+								return null;
+							}
+							
+							return (
+								<Card variant={'background'} key={tokenAddress}>
+									<div className={'flex flex-row space-x-4'}>
+										<div className={'-mt-1 flex flex-col'}>
+											<div className={'flex flex-row items-center space-x-2'}>
+												<h4 className={'text-lg font-bold text-neutral-700'}>{name}</h4>
+												<p className={'text-sm opacity-60'}>{`(v${symbol})`}</p>
+											</div>
+											<div className={'hidden md:flex'}>
+												<AddressWithActions
+													className={'text-sm font-normal'}
+													truncate={0}
+													address={tokenAddress} />
+											</div>
+											<div className={'flex md:hidden'}>
+												<AddressWithActions
+													className={'text-sm font-normal'}
+													truncate={8}
+													address={tokenAddress} />
+											</div>
+										</div>
+									</div>
+									<section aria-label={'strategies check'} className={'mt-3 flex flex-col pl-0'}>
+										<b className={'mb-1 font-mono text-sm text-neutral-500'}>{`(${missingTranslations[tokenAddress].length}) Missing Translations`}</b>
+										<TranslationStatusLine
+											key={`${tokenAddress}_translation`}
+											isValid={false}
+											content={missingTranslations[tokenAddress].join(', ')} />
+									</section>
+								</Card>
+							);
+						})
+						}
 					</div>
 				</div>
 			</Card>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -192,6 +192,10 @@ function	Index(): ReactNode {
 						})}
 
 						{settings.shouldShowEntity === 'tokens' && tokens && Object.keys(tokens).map((tokenAddress: string): ReactNode => {
+							if (!aggregatedData.tokens[toAddress(tokenAddress)]) {
+								return null;
+							}
+
 							const {name, symbol, missingTranslations} = aggregatedData.tokens[toAddress(tokenAddress)];
 
 							if (!missingTranslations) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -96,7 +96,7 @@ function	Index(): ReactNode {
 								<label
 									htmlFor={'checkbox-endorsed'}
 									className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
-									<p className={'pr-4'}>{'Show endorsed only'}</p>
+									<p className={'pr-4'}>{'Endorsed only'}</p>
 									<input
 										type={'checkbox'}
 										id={'checkbox-endorsed'}
@@ -107,7 +107,7 @@ function	Index(): ReactNode {
 								<label
 									htmlFor={'checkbox-anomalies'}
 									className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
-									<p className={'pr-4'}>{'Show anomalies only'}</p>
+									<p className={'pr-4'}>{'Anomalies only'}</p>
 									<input
 										type={'checkbox'}
 										id={'checkbox-anomalies'}
@@ -118,7 +118,7 @@ function	Index(): ReactNode {
 								<label
 									htmlFor={'checkbox-translations'}
 									className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
-									<p className={'pr-4'}>{'Show missing translations'}</p>
+									<p className={'pr-4'}>{'Missing translations'}</p>
 									<input
 										type={'checkbox'}
 										id={'checkbox-translations'}

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -26,4 +26,5 @@ export type TSettings = {
 	shouldShowOnlyEndorsed: boolean;
 	shouldShowVersion: 'all' | 'v2' | 'v3' | 'v4';
 	shouldShowMissingTranslations: boolean;
+	shouldShowEntity: 'vaults' | 'tokens';
 }

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -6,6 +6,7 @@ export type	TAnomalies = {
 	sufix: string | ReactElement,
 	onClick?: () => void
 }
+
 export type	TFixModalData = {
 	isOpen: boolean,
 	fix: {
@@ -15,6 +16,7 @@ export type	TFixModalData = {
 		instructions: (string | ReactElement)[]
 	}
 }
+
 export type	TAnomaliesSection = {
 	label: string,
 	anomalies: TAnomalies[],


### PR DESCRIPTION
## Description

* Add a `Dropdown` to toggle between "Vaults" and "Tokens"
* For each token (from endpoint `https://ydaemon.yearn.finance/${_chainID}/meta/tokens?loc=all`) check if there are any translations missing

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/49

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We'd like to be warned  of missing tokens' translations

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and saw the missing translations being displayed, refer to screenshot below

## Screenshots (if appropriate):

<img width="1233" alt="ySync" src="https://user-images.githubusercontent.com/78794805/188263619-4e83449a-f6d7-4721-b17a-036a718d8e11.png">

### Dropdown to select between "Vaults" and "Tokens"

<img width="1249" alt="Screen Shot 2022-09-03 at 6 57 15 pm" src="https://user-images.githubusercontent.com/78794805/188263629-78e262c0-4ff4-44f6-8251-f2bdee12a8ff.png">
