### PR TITLE
fix(risk): change the error condition to being in the Others group

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -347,7 +347,7 @@ function	VaultEntity({
 					<section aria-label={'strategies check'} className={'mt-4 flex flex-col pl-0 md:pl-0'}>
 						<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Risk Score'}</b>
 						{vault.strategies.map((strategy: any): ReactNode => {
-							const	hasRiskFramework = ((strategy?.risk?.TVLImpact || 0) + (strategy?.risk?.auditScore || 0) + (strategy?.risk?.codeReviewScore || 0) + (strategy?.risk?.complexityScore || 0) + (strategy?.risk?.longevityImpact || 0) + (strategy?.risk?.protocolSafetyScore || 0) + (strategy?.risk?.teamKnowledgeScore || 0) + (strategy?.risk?.testingScore || 0)) > 0;
+							const	hasRiskFramework = (strategy?.risk?.riskGroup || 'Others') !== 'Others';
 							return (
 								<StatusLine
 									key={`${strategy.address}_risk`}

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -19,7 +19,6 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 	const	[nonce, set_nonce] = useState(0);
 	const	[aggregatedData, set_aggregatedData] = useState<appTypes.TAllData>({vaults: {}, tokens: {}, protocols: {}});
 	const	[dataFromAPI, set_dataFromAPI] = useState<any[]>([]);
-	const	[riskFramework, set_riskFramework] = useState<any[]>([]);
 
 
 	/* 🔵 - Yearn Finance ******************************************************
@@ -31,7 +30,6 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 		const	[fromAPI, _ledgerSupport, _riskFramework, _metaFiles, strategies, tokens, protocols] = await Promise.all([
 			axios.get(`${process.env.YDAEMON_ENDPOINT}/${_chainID}/vaults/all?classification=any&strategiesRisk=withRisk`),
 			axios.get('https://raw.githubusercontent.com/LedgerHQ/app-plugin-yearn/develop/tests/yearn/b2c.json'),
-			axios.get('https://raw.githubusercontent.com/yearn/yearn-data-analytics/master/src/risk_framework/risks.json'),
 			axios.get(`https://api.github.com/repos/yearn/ydaemon/contents/data/meta/vaults/${_chainID}`),
 			axios.get(`${process.env.YDAEMON_ENDPOINT}/${_chainID}/meta/strategies?loc=all`),
 			axios.get(`${process.env.YDAEMON_ENDPOINT}/${_chainID}/tokens/all?loc=all`),
@@ -214,7 +212,6 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 
 		performBatchedUpdates((): void => {
 			set_dataFromAPI(fromAPI.data);
-			set_riskFramework(_riskFramework.data.filter((r: {network: number}): boolean => r.network === _chainID));
 			set_aggregatedData(_allData);
 			set_nonce((n): number => n + 1);
 		});
@@ -301,7 +298,6 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 	return (
 		<YearnContext.Provider value={{
 			dataFromAPI,
-			riskFramework,
 			aggregatedData,
 			onUpdateIconStatus,
 			onUpdateTokenIconStatus,

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -7,7 +7,6 @@ import type * as appTypes from 'types/types';
 
 const	YearnContext = createContext<appTypes.TYearnContext>({
 	dataFromAPI: [],
-	riskFramework: {},
 	aggregatedData: {vaults: {}, tokens: {}, protocols: {}},
 	onUpdateIconStatus: (): void => undefined,
 	onUpdateTokenIconStatus: (): void => undefined,
@@ -27,14 +26,14 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 	** anomalies.
 	**************************************************************************/
 	const getYearnDataSync = useCallback(async (_chainID: number): Promise<void> => {
-		const	[fromAPI, _ledgerSupport, _riskFramework, _metaFiles, strategies, tokens, protocols] = await Promise.all([
+		const	[fromAPI, _ledgerSupport, _metaFiles, strategies, tokens, protocols] = await Promise.all([
 			axios.get(`${process.env.YDAEMON_ENDPOINT}/${_chainID}/vaults/all?classification=any&strategiesRisk=withRisk`),
 			axios.get('https://raw.githubusercontent.com/LedgerHQ/app-plugin-yearn/develop/tests/yearn/b2c.json'),
 			axios.get(`https://api.github.com/repos/yearn/ydaemon/contents/data/meta/vaults/${_chainID}`),
 			axios.get(`${process.env.YDAEMON_ENDPOINT}/${_chainID}/meta/strategies?loc=all`),
 			axios.get(`${process.env.YDAEMON_ENDPOINT}/${_chainID}/tokens/all?loc=all`),
 			axios.get(`${process.env.YDAEMON_ENDPOINT}/${_chainID}/meta/protocols?loc=all`)
-		]) as [any, any, any, AxiosResponse<appTypes.TGHFile[]>, any, AxiosResponse<{[key: string]: appTypes.TExternalTokensFromYDaemon}>, any];
+		]) as [any, any, AxiosResponse<appTypes.TGHFile[]>, any, AxiosResponse<{[key: string]: appTypes.TExternalTokensFromYDaemon}>, any];
 
 		const YEARN_META_FILES = _metaFiles.data.map((meta): string => toAddress(meta.name.split('.')[0]));
 		const LANGUAGES = [...new Set(Object.values(strategies.data).map(({localization}: any): string[] => localization ? Object.keys(localization) : []).flat())];
@@ -63,8 +62,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 				));
 
 				const	hasValidStrategiesRisk = data.strategies.every((strategy: appTypes.TStrategy): boolean => {
-					const hasRiskFramework = ((strategy?.risk?.TVLImpact || 0) + (strategy?.risk?.auditScore || 0) + (strategy?.risk?.codeReviewScore || 0) + (strategy?.risk?.complexityScore || 0) + (strategy?.risk?.longevityImpact || 0) + (strategy?.risk?.protocolSafetyScore || 0) + (strategy?.risk?.teamKnowledgeScore || 0) + (strategy?.risk?.testingScore || 0)) > 0;
-					return hasRiskFramework;
+					return (strategy?.risk?.riskGroup || 'Others') !== 'Others';
 				});
 
 				const	hasYearnMetaFile = YEARN_META_FILES.includes(data.address);

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -39,7 +39,6 @@ export type	TFixModalData = {
 
 export type	TYearnContext = {
 	dataFromAPI: any[],
-	riskFramework: {}, // eslint-disable-line @typescript-eslint/ban-types
 	aggregatedData: TAllData,
 	onUpdateIconStatus: (address: string, status: boolean) => void,
 	onUpdateTokenIconStatus: (address: string, status: boolean, pureToken: boolean) => void,
@@ -69,6 +68,7 @@ export type TExternalTokensFromYDaemon = {
 
 
 export type	TRisk = {
+	riskGroup: string,
 	TVLImpact: number,
 	auditScore: number,
 	codeReviewScore: number,


### PR DESCRIPTION
## Description

Adds the riskGroup field, and denote as error when the riskGroup == "Others" or if the risk group does not exist.
Also remove the codes that fetch the risk framework json file from the data repo.

## Related Issue

Fixes https://github.com/yearn/ydaemon/issues/48

## Motivation and Context

There are currently a lot of strategies that belong to the Others group in the risk framework of yDaemon, which is not ideal since each strategy should either have its own specific scores or be deemed as Inactive.

## How Has This Been Tested?

Run locally through `yarn run dev`