### PR TITLE
feat: Detect if a protocol file is missing in Strategy tab

### DIFF
--- a/components/StrategyEntity.tsx
+++ b/components/StrategyEntity.tsx
@@ -1,21 +1,27 @@
 import React, {ReactElement} from 'react';
 import {AddressWithActions} from '@yearn-finance/web-lib/components';
-import type {TSettings} from 'types/types';
+import type {TFile, TSettings} from 'types/types';
 import {TStrategy} from 'types/entities';
 import StatusLine from './VaultEntity.StatusLine';
 
 type TProtocolStatus = {
-	isValid: boolean;
 	name: string;
+	isValid: boolean;
+	file?: TFile;
 }
 
 type TStrategyEntity = {
 	strategyData: TStrategy;
 	protocolNames: string[];
+	protocolFiles: TFile[];
 	statusSettings: TSettings;
 }
 
-function StrategyEntity({strategyData, protocolNames, statusSettings}: TStrategyEntity): ReactElement | null {
+function findFile(filename: string, files: TFile[]): TFile | undefined {
+	return files.find(({name}): boolean => name === filename.replace(/[^a-zA-Z0-9]/g, '').toUpperCase());
+}
+
+function StrategyEntity({strategyData, protocolNames, protocolFiles, statusSettings}: TStrategyEntity): ReactElement | null {
 	if (!strategyData) {
 		return null;
 	}
@@ -27,8 +33,9 @@ function StrategyEntity({strategyData, protocolNames, statusSettings}: TStrategy
 	}
 
 	const protocolsStatus = protocols.map((protocol): TProtocolStatus => ({
+		name: protocol,
 		isValid: protocolNames.includes(protocol),
-		name: protocol
+		file: findFile(protocol, protocolFiles)
 	}));
 
 	const hasAnomalies = protocolsStatus.some(({isValid}): boolean => !isValid);
@@ -65,20 +72,32 @@ function StrategyEntity({strategyData, protocolNames, statusSettings}: TStrategy
 			<div className={'flex flex-col p-4 pt-0'}>
 				<section aria-label={'strategies check'} className={'mt-4 flex flex-col pl-0 md:pl-0'}>
 					<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Protocol Validity'}</b>
-					{protocolsStatus.map(({isValid, name}: TProtocolStatus): ReactElement => {
+					{protocolsStatus.map(({name, isValid, file}: TProtocolStatus): ReactElement => {
 						return (
-							<StatusLine
-								key={`${name}_protocol`}
-								settings={statusSettings}
-								isValid={isValid}
-								prefix={(<span>
-									{'Name '}
-									{'"'}<span className={`underline ${isValid ? '' : 'text-red-900'}`}>
-										{name}
-									</span>{'"'}
-								</span>)}
-								suffix={'for protocol'} />
-								
+							<>
+								<StatusLine
+									key={`${name}_protocol_file`}
+									settings={statusSettings}
+									isValid={!!file}
+									prefix={(<span>
+										{'File '}
+										<a href={file?.originalName ? file?.url : '#'} target={file?.originalName ? '_blank' : ''} className={`tabular-nums text-red-900 ${file?.originalName ? 'underline' : ''}`} rel={'noreferrer'}>
+											{file?.originalName ?? `${name.replace(/[^a-zA-Z0-9]/g, '')}.json`}
+										</a>
+									</span>)}
+									suffix={'for strategy\'s protocol'} />
+								{!!file && <StatusLine
+									key={`${name}_protocol`}
+									settings={statusSettings}
+									isValid={isValid}
+									prefix={(<span>
+										{'Name '}
+										{'"'}<span className={`underline ${isValid ? '' : 'text-red-900'}`}>
+											{name}
+										</span>{'"'}
+									</span>)}
+									suffix={'for strategy\'s protocol'} />}
+							</>
 						);
 					})}
 				</section>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -247,7 +247,11 @@ function	Index(): ReactNode {
 		set_strategies(aggregatedData.strategies);
 	}, [dataFromAPI, appSettings, chainID, aggregatedData.tokens, aggregatedData.protocols, aggregatedData.strategies]);
 
-	useMemo((): void => set_protocolNames(Object.keys(protocols || {}).map((key: string): string => protocols[key].name)), [protocols]);
+	useMemo((): void => {
+		if (protocols?.protocol) {
+			set_protocolNames(Object.keys(protocols.protocol).map((key: string): string => protocols.protocol[key].name));
+		}
+	}, [protocols?.protocol]);
 
 	const	errorCount = useMemo((): number => {
 		if (appSettings.shouldShowEntity === 'tokens') {
@@ -343,12 +347,12 @@ function	Index(): ReactNode {
 							);
 						})}
 
-						{appSettings.shouldShowEntity === 'protocols' && protocols && Object.keys(protocols).map((protocol: string): ReactNode => {
-							if (!aggregatedData.protocols[protocol]) {
+						{appSettings.shouldShowEntity === 'protocols' && protocols.protocol && Object.keys(protocols.protocol).map((protocol: string): ReactNode => {
+							if (!protocols.protocol[protocol]) {
 								return null;
 							}
 							
-							const {missingTranslations} = aggregatedData.protocols[protocol];
+							const {missingTranslations} = protocols.protocol[protocol];
 
 							if (!missingTranslations) {
 								return null;
@@ -379,6 +383,7 @@ function	Index(): ReactNode {
 								<StrategyEntity
 									key={strategyAddress}
 									statusSettings={appSettings}
+									protocolFiles={protocols.files}
 									protocolNames={protocolNames}
 									strategyData={aggregatedData.strategies[strategyAddress]} />
 							);

--- a/types/entities.tsx
+++ b/types/entities.tsx
@@ -1,48 +1,56 @@
+import {TFile} from './types';
+
 // Vault entity
 export type	TVaultData = {
-	hasLedgerIntegration: boolean,
-	hasValidStrategiesDescriptions: boolean,
-	hasValidStrategiesTranslations: boolean,
-	hasValidStrategiesRisk: boolean,
-	hasValidIcon: boolean,
-	hasValidTokenIcon: boolean,
-	hasYearnMetaFile: boolean,
-	hasValidPrice: boolean,
-	hasNewAPY: boolean,
-	hasErrorAPY: boolean,
-	missingTranslations: {[key: string]: string[]},
-	address: string,
-	name: string,
-	icon: string,
-	version: string,
-	strategies: any[],
+	hasLedgerIntegration: boolean;
+	hasValidStrategiesDescriptions: boolean;
+	hasValidStrategiesTranslations: boolean;
+	hasValidStrategiesRisk: boolean;
+	hasValidIcon: boolean;
+	hasValidTokenIcon: boolean;
+	hasYearnMetaFile: boolean;
+	hasValidPrice: boolean;
+	hasNewAPY: boolean;
+	hasErrorAPY: boolean;
+	missingTranslations: {[key: string]: string[]};
+	address: string;
+	name: string;
+	icon: string;
+	version: string;
+	strategies: any[];
 }
+
 export type	TVaultsData = {[key: string]: TVaultData}
 
 // Token entity
 export type	TTokenData = {
-	address: string,
-	name: string,
-	symbol: string,
-	price: string,
-	missingTranslations: {[key: string]: string[]},
-	hasValidTokenIcon: boolean,
-	hasValidPrice: boolean
+	address: string;
+	name: string;
+	symbol: string;
+	price: string;
+	missingTranslations: {[key: string]: string[]};
+	hasValidTokenIcon: boolean;
+	hasValidPrice: boolean;
 }
+
 export type	TTokensData = {[key: string]: TTokenData}
 
 // Protocol entity
 export type	TProtocolData = {
 	name?: string;
-	missingTranslations: string[],
-	missingProtocolFile: boolean,
+	missingTranslations: string[];
+	missingProtocolFile: boolean;
 }
-export type	TProtocolsData = {[key: string]: TProtocolData}
+
+export type	TProtocolsData = {
+	protocol: {[key: string]: TProtocolData};
+	files: TFile[];
+}
 
 export type	TStrategy = {
-	address: string,
-	name: string,
-	description?: string,
-	protocols?: string[],
+	address: string;
+	name: string;
+	description?: string;
+	protocols?: string[];
 }
 export type	TStrategiesData = {[key: string]: TStrategy}

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -46,8 +46,16 @@ export type	TYearnContext = {
 }
 
 export type	TGHFile = {
-	name: string
+	name: string;
+	html_url: string;
 }
+
+export type TFile = {
+	name: string;
+	originalName: string;
+	url: string;
+}
+
 export type TExternalTokensFromYDaemon = {
 	address: string,
 	name: string,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Checks all the protocols for a strategy have a corresponding file.

In case the file exists, it also links to the file in the yDaemon repo

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/72

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It's helpful to know if a protocol file is missing so that we can go and create one

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and saw the file status being correctly displayed, refer to screenshots below

## Screenshots (if appropriate):

### Only anomalies

<img width="2352" alt="Screen Shot 2022-10-04 at 6 29 49 pm" src="https://user-images.githubusercontent.com/78794805/193862175-5b569d1e-d08f-4887-b67e-4bca9915d64d.png">

### All issues

<img width="2352" alt="Screen Shot 2022-10-04 at 6 29 58 pm" src="https://user-images.githubusercontent.com/78794805/193862168-a98d3e10-2c94-41c0-8746-18da6fbadef9.png">
