### PR TITLE
feat: Check to know to hide vaults when users cannot deposit to them

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -50,7 +50,7 @@ function	VaultEntity({
 		|| vaultData?.hasErrorAPY
 		|| vaultData?.hasNewAPY
 		|| !vaultData?.token?.description
-		|| !isRetirementValid(vault)
+		|| !vaultData?.hasValidRetirement
 	);
 
 	function	onTriggerModalForLedger(): void {
@@ -267,11 +267,11 @@ function	VaultEntity({
 					label={'Retirement'}
 					settings={vaultSettings}
 					anomalies={[{
-						isValid: isRetirementValid(vault),
+						isValid: vaultData?.hasValidRetirement,
 						prefix: 'Retirement',
 						suffix: (
 							<span>
-								{isRetirementValid(vault) ? 'for vault' : 'for vault, it should be retired=true'}
+								{vaultData?.hasValidRetirement ? 'for vault' : 'for vault, it should be retired=true'}
 							</span>
 						)
 					}]} />
@@ -522,8 +522,6 @@ function	VaultEntity({
 	);
 }
 
-function isRetirementValid(vault: any): boolean {
-	return Number(vault.details.depositLimit) === 0 && vault.details.retired;
-}
+
 
 export default VaultEntity;

--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -50,6 +50,7 @@ function	VaultEntity({
 		|| vaultData?.hasErrorAPY
 		|| vaultData?.hasNewAPY
 		|| !vaultData?.token?.description
+		|| !isRetirementValid(vault)
 	);
 
 	function	onTriggerModalForLedger(): void {
@@ -262,6 +263,19 @@ function	VaultEntity({
 				</div>
 			</div>
 			<div className={'flex flex-col p-4 pt-0'}>
+				<AnomaliesSection
+					label={'Retirement'}
+					settings={vaultSettings}
+					anomalies={[{
+						isValid: isRetirementValid(vault),
+						prefix: 'Retirement',
+						suffix: (
+							<span>
+								{isRetirementValid(vault) ? 'for vault' : 'for vault, it should be retired=true'}
+							</span>
+						)
+					}]} />
+
 				<AnomaliesSection
 					label={'Yearn Meta File'}
 					settings={vaultSettings}
@@ -506,6 +520,10 @@ function	VaultEntity({
 				onClose={(): void => set_fixModalData(defaultFixModalData)} />
 		</div>
 	);
+}
+
+function isRetirementValid(vault: any): boolean {
+	return Number(vault.details.depositLimit) === 0 && vault.details.retired;
 }
 
 export default VaultEntity;

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -156,6 +156,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasValidTokenIcon: true,
 					hasValidPrice: data.tvl.price > 0,
 					hasYearnMetaFile,
+					hasValidRetirement: isRetirementValid(data),
 					hasErrorAPY: data.apy.type === 'error',
 					hasNewAPY: data.apy.type === 'new',
 					missingTranslations,
@@ -193,6 +194,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasNewAPY: false,
 					hasErrorAPY: false,
 					hasYearnMetaFile,
+					hasValidRetirement: isRetirementValid(data),
 					missingTranslations: {},
 					token: data?.token,
 					address: toAddress(data.address),
@@ -230,6 +232,7 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasNewAPY: false,
 					hasErrorAPY: false,
 					hasYearnMetaFile,
+					hasValidRetirement: isRetirementValid(data),
 					missingTranslations: {},
 					token: data?.token,
 					address: toAddress(data.address),
@@ -448,6 +451,10 @@ export const getExporterPartners = (exporterPartnersRawData: string): {
 	
 	return result;
 };
+
+function isRetirementValid(vault: any): boolean {
+	return Number(vault?.details?.depositLimit) === 0 && vault?.details?.retired;
+}
 
 export const useYearn = (): appTypes.TYearnContext => useContext(YearnContext);
 export default useYearn;

--- a/types/entities.tsx
+++ b/types/entities.tsx
@@ -26,6 +26,7 @@ export type	TVaultData = {
 	hasValidPrice: boolean;
 	hasNewAPY: boolean;
 	hasErrorAPY: boolean;
+	hasValidRetirement: boolean;
 	missingTranslations: {[key: string]: string[]};
 	token?: TVaultToken;
 	address: string;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Check if the vault deposit limit = 0 and if in [meta if retired = false](https://github.com/yearn/ydaemon/blob/develop/data/meta/vaults/1/0xe9Dc63083c464d6EDcCFf23444fF3CFc6886f6FB.json#L11) if this is the case show an error retired=true on ysync

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/83

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

So we have a check to know to hide vaults when users cannot deposit to them

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, refer to screenshot below

## Screenshots (if appropriate):

<img width="587" alt="Screenshot_7_2_2023__11_11" src="https://user-images.githubusercontent.com/78794805/217201529-5ca8eda8-ca5e-408a-a599-cee479fb6e16.png">
