### PR TITLE
feat: Add a check if a migration's vault was closed

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -51,6 +51,7 @@ function	VaultEntity({
 		|| vaultData?.hasNewAPY
 		|| !vaultData?.token?.description
 		|| !vaultData?.hasValidRetirement
+		|| !vaultData?.hasValidMigrationTargetVault
 	);
 
 	function	onTriggerModalForLedger(): void {
@@ -334,6 +335,15 @@ function	VaultEntity({
 						isWarning: !vaultData?.hasLedgerIntegration.deployed && vaultData?.hasLedgerIntegration.incoming,
 						onClick: onTriggerModalForLedger,
 						prefix: 'Ledger integration',
+						suffix: 'for vault'
+					}]} />
+
+				<AnomaliesSection
+					label={'Migrations'}
+					settings={vaultSettings}
+					anomalies={[{
+						isValid: vaultData?.hasValidMigrationTargetVault,
+						prefix: 'Migration\'s vault',
 						suffix: 'for vault'
 					}]} />
 

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -143,6 +143,18 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					}
 				}
 
+				
+				const	migrationTargetVaultAddress = data.migration.address;
+				const	migrationTargetVault = fromAPI.data.find((vault: { address: string }): boolean => {
+					return toAddress(vault.address) === toAddress(migrationTargetVaultAddress);
+				});
+
+				let		hasValidMigrationTargetVault = true;
+				if (migrationTargetVault) {
+					const	{depositsDisabled, depositLimit} = migrationTargetVault?.details || {};
+					hasValidMigrationTargetVault = !(depositsDisabled && BigNumber.from(depositLimit).eq(0));
+				}
+				
 				_allData.vaults[toAddress(data.address)] = {
 					// Ledger live integration only for mainnet
 					hasLedgerIntegration: {
@@ -166,7 +178,8 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					name: data.display_name || data.name,
 					icon: data.icon,
 					version: data.version,
-					strategies: data.strategies
+					strategies: data.strategies,
+					hasValidMigrationTargetVault
 				};
 			}
 		}
@@ -202,7 +215,8 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					name: data?.contractName || '',
 					icon: '',
 					version: 'Unknown',
-					strategies: []
+					strategies: [],
+					hasValidMigrationTargetVault: false
 
 				};
 				continue;
@@ -240,7 +254,8 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					name: data?.contractName || '',
 					icon: '',
 					version: 'Unknown',
-					strategies: []
+					strategies: [],
+					hasValidMigrationTargetVault: false
 
 				};
 				continue;

--- a/types/entities.tsx
+++ b/types/entities.tsx
@@ -34,6 +34,7 @@ export type	TVaultData = {
 	icon: string;
 	version: string;
 	strategies: any[];
+	hasValidMigrationTargetVault: boolean,
 }
 
 export type	TVaultsData = {[key: string]: TVaultData}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add a check if a migration's vault was closed:

* deposits disabled = true;
* deposit limit is 0

However, we have a few cases where the `address` === `migration.address`

<img width="552" alt="ySync" src="https://user-images.githubusercontent.com/78794805/225925389-aad96b0c-2fb0-45fb-b92e-1031d97ade51.png">

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/85

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We have live migrations in meta that will fail to go through.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally

## Screenshots (if appropriate):

<img width="610" alt="Screenshot 2023-03-17 at 15 58 25" src="https://user-images.githubusercontent.com/78794805/225925994-22dbeae6-951e-4b33-ace1-057f86b51c35.png">
