### PR TITLE
fix: Risk group

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -365,7 +365,7 @@ function	VaultEntity({
 
 				{vaultData?.hasValidStrategiesRisk && vaultSettings.shouldShowOnlyAnomalies ? null : (
 					<section aria-label={'strategies check'} className={'mt-4 flex flex-col pl-0 md:pl-0'}>
-						<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Risk Score'}</b>
+						<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Risk'}</b>
 						{vault.strategies.map((strategy: any): ReactNode => {
 							const	hasRiskFramework = (strategy?.risk?.riskGroup || 'Others') !== 'Others';
 							return (


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Rename the risk group from "Risk Score" to just "Risk"

## Related Issue

Fixes https://github.com/yearn/ySync/issues/87

<!--- Please link to the issue here -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We had the same label (i.e. "Risk Score") in two groups

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, see screenshot below

## Screenshots (if appropriate):

<img width="1241" alt="Screenshot 2023-03-30 at 11 49 20" src="https://user-images.githubusercontent.com/78794805/228782262-c5429422-22c1-4951-9e6a-bd2cd25edb57.png">
