### PR TITLE
fix: Risk score details inside risk details

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -393,14 +393,14 @@ function	VaultEntity({
 						<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Risk Score'}</b>
 						{vault.strategies.map((strategy: any): ReactNode => {
 							const sum = (
-								(strategy?.risk?.TVLImpact || 0)
-								+ (strategy?.risk?.auditScore || 0)
-								+ (strategy?.risk?.codeReviewScore || 0)
-								+ (strategy?.risk?.complexityScore || 0)
-								+ (strategy?.risk?.longevityImpact || 0)
-								+ (strategy?.risk?.protocolSafetyScore || 0)
-								+ (strategy?.risk?.teamKnowledgeScore || 0)
-								+ (strategy?.risk?.testingScore || 0)
+								(strategy?.risk?.riskDetails?.TVLImpact || 0)
+								+ (strategy?.risk?.riskDetails?.auditScore || 0)
+								+ (strategy?.risk?.riskDetails?.codeReviewScore || 0)
+								+ (strategy?.risk?.riskDetails?.complexityScore || 0)
+								+ (strategy?.risk?.riskDetails?.longevityImpact || 0)
+								+ (strategy?.risk?.riskDetails?.protocolSafetyScore || 0)
+								+ (strategy?.risk?.riskDetails?.teamKnowledgeScore || 0)
+								+ (strategy?.risk?.riskDetails?.testingScore || 0)
 							);
 							return (
 								<StatusLine


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

The risk scores were not being calculated correctly since those scores now live inside a `riskDetails` property.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Have the correct scores being displayed

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, refer to the screenshots below

## Screenshots (if appropriate):

### Before

<img width="599" alt="before" src="https://user-images.githubusercontent.com/78794805/228908734-844208a4-83d7-47e8-9841-9dbca0641074.png">

### After

<img width="624" alt="now" src="https://user-images.githubusercontent.com/78794805/228908803-1a1194f0-4a67-4a43-8051-f25332f9f45c.png">
