### PR TITLE
feat: Make a toggle for Icon and Price

### DIFF
--- a/components/TokenEntity.tsx
+++ b/components/TokenEntity.tsx
@@ -37,13 +37,6 @@ function	TokenEntity({
 
 	return (
 		<div className={'rounded-lg bg-neutral-200'} key={tokenData.address}>
-			<pre>
-				{JSON.stringify({
-					shouldRenderDueToMissingTranslations,
-					shouldRenderDueToMissingIcon,
-					shouldRenderDueToMissingPrice
-				}, null, 2)}
-			</pre>
 			<div className={'flex flex-row space-x-4 rounded-t-lg bg-neutral-300/40 p-4'}>
 				<div className={'h-10 min-h-[40px] w-10 min-w-[40px] rounded-full bg-neutral-200'}>
 					<Image

--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -474,7 +474,7 @@ function	VaultEntity({
 
 				{Object.keys((aggregatedData?.vaults[toAddress(vault.address)]?.missingTranslations) || []).length !== 0 && vaultSettings.shouldShowMissingTranslations ? (
 					<section aria-label={'strategies check'} className={'mt-4 flex flex-col pl-0 md:pl-0'}>
-						<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Missing stst'}</b>
+						<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Missing Translations'}</b>
 						{Object.keys(vaultData?.missingTranslations).map((strategyAddress: any): ReactNode => {
 							const missingTranslation = vaultData?.missingTranslations;
 							const shortAddress = `${strategyAddress.substr(0, 8)}...${strategyAddress.substr(strategyAddress.length-8, strategyAddress.length)}`; 

--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -286,44 +286,47 @@ function	VaultEntity({
 						suffix: 'for vault'
 					}]} />
 
-				<AnomaliesSection
-					label={'Icon'}
-					settings={vaultSettings}
-					anomalies={[{
-						isValid: vaultData?.hasValidIcon,
-						prefix: 'Icon',
-						suffix: (
-							<span className={'inline'}>
-								{'for vault '}
-								<a href={`${networks[chainID].explorerBaseURI}/address/${vault.address}`} target={'_blank'} className={`underline ${vaultData?.hasValidIcon ? 'tabular-nums' : 'tabular-nums text-red-900'}`} rel={'noreferrer'}>
-									{vault.symbol || 'not_set'}
-								</a>
-								<button onClick={(): void => copyToClipboard(`${networks[chainID].explorerBaseURI}/address/${vault.address}`)}>
-									<Copy className={'ml-2 inline h-4 w-4 text-neutral-500/40 transition-colors hover:text-neutral-500'} />
-								</button>
-								<a href={`${networks[chainID].explorerBaseURI}/address/${vault.address}`} target={'_blank'} rel={'noreferrer'}>
-									<LinkOut className={'ml-2 inline h-4 w-4 text-neutral-500/40 transition-colors hover:text-neutral-500'} />
-								</a>
-							</span>
-						)
-					}, {
-						isValid: vaultData?.hasValidTokenIcon,
-						prefix: 'Icon',
-						suffix: (
-							<span className={'inline'}>
-								{'for underlying token '}
-								<a href={`${networks[chainID].explorerBaseURI}/address/${vault.token.address}`} target={'_blank'} className={`underline ${vaultData?.hasValidTokenIcon ? 'tabular-nums' : 'tabular-nums text-red-900'}`} rel={'noreferrer'}>
-									{vault.token.symbol || 'not_set'}
-								</a>
-								<button onClick={(): void => copyToClipboard(`${networks[chainID].explorerBaseURI}/address/${vault.token.address}`)}>
-									<Copy className={'ml-2 inline h-4 w-4 text-neutral-500/40 transition-colors hover:text-neutral-500'} />
-								</button>
-								<a href={`${networks[chainID].explorerBaseURI}/address/${vault.token.address}`} target={'_blank'} rel={'noreferrer'}>
-									<LinkOut className={'ml-2 inline h-4 w-4 text-neutral-500/40 transition-colors hover:text-neutral-500'} />
-								</a>
-							</span>
-						)
-					}]} />
+				{vaultSettings.shouldShowIcons && (
+					<AnomaliesSection
+						label={'Icon'}
+						settings={vaultSettings}
+						anomalies={[{
+							isValid: vaultData?.hasValidIcon,
+							prefix: 'Icon',
+							suffix: (
+								<span className={'inline'}>
+									{'for vault '}
+									<a href={`${networks[chainID].explorerBaseURI}/address/${vault.address}`} target={'_blank'} className={`underline ${vaultData?.hasValidIcon ? 'tabular-nums' : 'tabular-nums text-red-900'}`} rel={'noreferrer'}>
+										{vault.symbol || 'not_set'}
+									</a>
+									<button onClick={(): void => copyToClipboard(`${networks[chainID].explorerBaseURI}/address/${vault.address}`)}>
+										<Copy className={'ml-2 inline h-4 w-4 text-neutral-500/40 transition-colors hover:text-neutral-500'} />
+									</button>
+									<a href={`${networks[chainID].explorerBaseURI}/address/${vault.address}`} target={'_blank'} rel={'noreferrer'}>
+										<LinkOut className={'ml-2 inline h-4 w-4 text-neutral-500/40 transition-colors hover:text-neutral-500'} />
+									</a>
+								</span>
+							)
+						}, {
+							isValid: vaultData?.hasValidTokenIcon,
+							prefix: 'Icon',
+							suffix: (
+								<span className={'inline'}>
+									{'for underlying token '}
+									<a href={`${networks[chainID].explorerBaseURI}/address/${vault.token.address}`} target={'_blank'} className={`underline ${vaultData?.hasValidTokenIcon ? 'tabular-nums' : 'tabular-nums text-red-900'}`} rel={'noreferrer'}>
+										{vault.token.symbol || 'not_set'}
+									</a>
+									<button onClick={(): void => copyToClipboard(`${networks[chainID].explorerBaseURI}/address/${vault.token.address}`)}>
+										<Copy className={'ml-2 inline h-4 w-4 text-neutral-500/40 transition-colors hover:text-neutral-500'} />
+									</button>
+									<a href={`${networks[chainID].explorerBaseURI}/address/${vault.token.address}`} target={'_blank'} rel={'noreferrer'}>
+										<LinkOut className={'ml-2 inline h-4 w-4 text-neutral-500/40 transition-colors hover:text-neutral-500'} />
+									</a>
+								</span>
+							)
+						}]}
+					/>
+				)}
 
 				<AnomaliesSection
 					label={'Ledger Live'}
@@ -337,21 +340,24 @@ function	VaultEntity({
 						suffix: 'for vault'
 					}]} />
 
-				<AnomaliesSection
-					label={'Price'}
-					settings={vaultSettings}
-					anomalies={[{
-						isValid: vaultData?.hasValidPrice,
-						prefix: 'Price',
-						suffix: (
-							<span>
-								{'for vault '}
-								<a href={`${networks[chainID].explorerBaseURI}/address/${vault.address}`} target={'_blank'} className={`underline ${vaultData?.hasValidPrice ? '' : 'text-red-900'}`} rel={'noreferrer'}>
-									{vaultData?.name}
-								</a>
-							</span>
-						)
-					}]} />
+				{vaultSettings.shouldShowPrice && (
+					<AnomaliesSection
+						label={'Price'}
+						settings={vaultSettings}
+						anomalies={[{
+							isValid: vaultData?.hasValidPrice,
+							prefix: 'Price',
+							suffix: (
+								<span>
+									{'for vault '}
+									<a href={`${networks[chainID].explorerBaseURI}/address/${vault.address}`} target={'_blank'} className={`underline ${vaultData?.hasValidPrice ? '' : 'text-red-900'}`} rel={'noreferrer'}>
+										{vaultData?.name}
+									</a>
+								</span>
+							)
+						}]}
+					/>
+				)}
 
 				<AnomaliesSection
 					label={'Strategies'}
@@ -468,7 +474,7 @@ function	VaultEntity({
 
 				{Object.keys((aggregatedData?.vaults[toAddress(vault.address)]?.missingTranslations) || []).length !== 0 && vaultSettings.shouldShowMissingTranslations ? (
 					<section aria-label={'strategies check'} className={'mt-4 flex flex-col pl-0 md:pl-0'}>
-						<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Missing Translations'}</b>
+						<b className={'mb-1 font-mono text-sm text-neutral-500'}>{'Missing stst'}</b>
 						{Object.keys(vaultData?.missingTranslations).map((strategyAddress: any): ReactNode => {
 							const missingTranslation = vaultData?.missingTranslations;
 							const shortAddress = `${strategyAddress.substr(0, 8)}...${strategyAddress.substr(strategyAddress.length-8, strategyAddress.length)}`; 

--- a/next.config.js
+++ b/next.config.js
@@ -15,7 +15,8 @@ module.exports = (phase) => withPWA({
 	images: {
 		domains: [
 			'rawcdn.githack.com',
-			'raw.githubusercontent.com'
+			'raw.githubusercontent.com',
+			'assets.smold.app'
 		]
 	},
 	env: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,6 +17,8 @@ const	defaultSettings: TSettings = {
 	shouldShowOnlyEndorsed: true,
 	shouldShowVersion: 'v4',
 	shouldShowMissingTranslations: false,
+	shouldShowIcons: true,
+	shouldShowPrice: true,
 	shouldShowEntity: 'vaults'
 };
 
@@ -74,6 +76,50 @@ const TranslationsCheckbox = ({appSettings, set_appSettings}: {
 	</label>;
 };
 
+const IconsCheckbox = ({appSettings, set_appSettings}: {
+	appSettings: TSettings,
+	set_appSettings: (s: TSettings) => void
+}): ReactElement | null => {
+	return <label
+		htmlFor={'checkbox-icons'}
+		className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
+		<p className={'pr-4'}>{'Icons'}</p>
+		<input
+			type={'checkbox'}
+			id={'checkbox-icons'}
+			className={'ml-2 rounded-lg'}
+			checked={appSettings.shouldShowIcons}
+			onChange={(): void => {
+				set_appSettings({
+					...appSettings,
+					shouldShowIcons: !appSettings.shouldShowIcons
+				});
+			}} />
+	</label>;
+};
+
+const PriceCheckbox = ({appSettings, set_appSettings}: {
+	appSettings: TSettings,
+	set_appSettings: (s: TSettings) => void
+}): ReactElement | null => {
+	return <label
+		htmlFor={'checkbox-price'}
+		className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
+		<p className={'pr-4'}>{'Price'}</p>
+		<input
+			type={'checkbox'}
+			id={'checkbox-price'}
+			className={'ml-2 rounded-lg'}
+			checked={appSettings.shouldShowPrice}
+			onChange={(): void => {
+				set_appSettings({
+					...appSettings,
+					shouldShowPrice: !appSettings.shouldShowPrice
+				});
+			}} />
+	</label>;
+};
+
 function	Filters({appSettings, set_appSettings}: {
 	appSettings: TSettings,
 	set_appSettings: (s: TSettings) => void
@@ -83,6 +129,8 @@ function	Filters({appSettings, set_appSettings}: {
 			<>
 				<AnomaliesCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
 				<TranslationsCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
+				<IconsCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
+				<PriceCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
 				<span
 					className={'col-span-2 flex w-full flex-row items-center overflow-hidden rounded-lg bg-neutral-200/60 font-mono text-sm text-neutral-500 transition-colors md:w-fit'}>
 					<p className={'pr-4 pl-2'}>{'Version'}</p>
@@ -158,6 +206,8 @@ function	Filters({appSettings, set_appSettings}: {
 			<>
 				<AnomaliesCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
 				<TranslationsCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
+				<IconsCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
+				<PriceCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
 			</>
 		);
 	}

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -7,6 +7,8 @@ export type TSettings = {
 	shouldShowOnlyAnomalies: boolean,
 	shouldShowOnlyEndorsed: boolean,
 	shouldShowMissingTranslations: boolean,
+	shouldShowIcons: boolean,
+	shouldShowPrice: boolean,
 	shouldShowVersion: TVersions,
 	shouldShowEntity: TEntity,
 }


### PR DESCRIPTION
## Description

Make a toggle for Icon and Price, not just anomalies but actually just hide/show icon and price

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/92

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We want to show/hide icon and price fields

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot 2023-06-16 at 22 17 25" src="https://github.com/yearn/ySync/assets/78794805/7674b5e2-cb0a-4744-bafb-4a2b8c02ccc1">
<img width="1582" alt="Screenshot 2023-06-16 at 22 17 21" src="https://github.com/yearn/ySync/assets/78794805/dfb19d5e-ab7f-4c09-ba3e-e3f84c1d2c91">
