### PR TITLE
feat: Improve logic to show/hide based on selected checkbox

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -227,6 +227,18 @@ function	VaultEntity({
 		return null;
 	}
 
+	const {shouldShowIcons, shouldShowPrice} = vaultSettings;
+
+	const hasMissingIconAnomaly = !vaultData.hasValidTokenIcon;
+	const hasMissingPriceAnomaly = !vaultData.hasValidPrice;
+
+	const shouldRenderDueToMissingIcon = hasMissingIconAnomaly && shouldShowIcons;
+	const shouldRenderDueToMissingPrice = hasMissingPriceAnomaly && shouldShowPrice;
+
+	if (!shouldRenderDueToMissingIcon && !shouldRenderDueToMissingPrice) {
+		return null;
+	}
+
 	return (
 		<div className={'rounded-lg bg-neutral-200'}>
 			<div className={'flex flex-row space-x-4 rounded-t-lg bg-neutral-300/40 p-4'}>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Improve the logic so that we show/hide the whole card based on which checkbox is selected

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/94

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When unchecking token icons those with only a token icon error, their boxes stay around when they should disappear

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally, refer to screenshot below

## Screenshots (if appropriate):

<img width="1470" alt="Screenshot 2023-06-26 at 10 05 59" src="https://github.com/yearn/ySync/assets/78794805/d14e4db2-6664-4855-8af3-7bcb8a2e4e2e">
