### PR TITLE
fix: Bug not pulling in all vaults on optimism

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -235,7 +235,7 @@ function	VaultEntity({
 	const shouldRenderDueToMissingIcon = hasMissingIconAnomaly && shouldShowIcons;
 	const shouldRenderDueToMissingPrice = hasMissingPriceAnomaly && shouldShowPrice;
 
-	if (!shouldRenderDueToMissingIcon && !shouldRenderDueToMissingPrice) {
+	if (!hasAnomalies && (!shouldRenderDueToMissingIcon && !shouldRenderDueToMissingPrice)) {
 		return null;
 	}
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Filter out only the vaults that don't have anomalies

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/ySync/issues/100

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Show all vaults on optimism

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, screenshot below

## Screenshots (if appropriate):
<img width="1582" alt="Screenshot 2023-07-07 at 15 36 52" src="https://github.com/yearn/ySync/assets/78794805/b9d971c2-7585-431d-91a9-8e828b52e8df">
