### PR TITLE
fix: Show vaults without anomalies

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -223,10 +223,6 @@ function	VaultEntity({
 		});
 	}
 
-	if (!hasAnomalies && vaultSettings.shouldShowOnlyAnomalies) {
-		return null;
-	}
-
 	const {shouldShowIcons, shouldShowPrice} = vaultSettings;
 
 	const hasMissingIconAnomaly = !vaultData?.hasValidTokenIcon;
@@ -235,7 +231,7 @@ function	VaultEntity({
 	const shouldRenderDueToMissingIcon = hasMissingIconAnomaly && shouldShowIcons;
 	const shouldRenderDueToMissingPrice = hasMissingPriceAnomaly && shouldShowPrice;
 
-	if (!hasAnomalies && (!shouldRenderDueToMissingIcon && !shouldRenderDueToMissingPrice)) {
+	if ((!hasAnomalies && vaultSettings.shouldShowOnlyAnomalies) && (!shouldRenderDueToMissingIcon && !shouldRenderDueToMissingPrice)) {
 		return null;
 	}
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Vaults without anomalies were being filtered in `VaultEntity.tsx`, they should only be filtered if `shouldShowOnlyAnomalies` is `true`

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/ySync/issues/103

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Show vaults with no errors on arbi or ftm

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, screenshot below (arbi/ftm)

## Screenshots (if appropriate):

### FTM

<img width="1582" alt="Screenshot 2023-07-30 at 13 18 03" src="https://github.com/yearn/ySync/assets/78794805/72319ea0-eafd-450b-839c-aa07b77611c9">

### Arbitrum
<img width="1582" alt="Screenshot 2023-07-30 at 13 17 58" src="https://github.com/yearn/ySync/assets/78794805/4354c05d-b8cc-4490-b656-3a1dd82de97b">
