### PR TITLE
fix: Risk Score shows KO for strategy but isn't an anomaly

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -473,7 +473,7 @@ function VaultEntity({
 								<StatusLine
 									key={`${riskScore.strategy.address}_risk`}
 									settings={vaultSettings}
-									isValid={!riskScore.isValid}
+									isValid={riskScore.isValid}
 									prefix={'Risk Score '}
 									suffix={(
 										<span>


### PR DESCRIPTION
Fixes https://github.com/yearn/ySync/issues/111

Logic should check if `isValid`, rather than the opposite