### PR TITLE
feat: Add a "Select all" for the filters

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,6 +13,7 @@ import StrategyEntity from 'components/StrategyEntity';
 import PartnerEntity from 'components/PartnerEntity';
 
 const defaultSettings: TSettings = {
+	shouldShowAllFilters: true,
 	shouldShowOnlyAnomalies: true,
 	shouldShowOnlyEndorsed: true,
 	shouldShowVersion: 'v4',
@@ -58,6 +59,41 @@ const AnomaliesCheckbox = ({appSettings, set_appSettings}: {
 				set_appSettings({
 					...appSettings,
 					shouldShowOnlyAnomalies: !appSettings.shouldShowOnlyAnomalies
+				});
+			}} />
+	</label>;
+};
+
+const SelectAllCheckbox = ({appSettings, set_appSettings}: {
+	appSettings: TSettings,
+	set_appSettings: (s: TSettings) => void
+}): ReactElement | null => {
+	return <label
+		htmlFor={'checkbox-anomalies'}
+		className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>
+		<p className={'pr-4'}>{'Select All Filters'}</p>
+		<input
+			type={'checkbox'}
+			id={'checkbox-select-all'}
+			className={'ml-2 rounded-lg'}
+			checked={appSettings.shouldShowAllFilters}
+			onChange={(): void => {
+				const isSelectAllChecked = !appSettings.shouldShowAllFilters;
+				set_appSettings({
+					...appSettings,
+					shouldShowAllFilters: isSelectAllChecked,
+					shouldShowMissingTranslations: isSelectAllChecked,
+					shouldShowIcons: isSelectAllChecked,
+					shouldShowPrice: isSelectAllChecked,
+					shouldShowRetirement: isSelectAllChecked,
+					shouldShowYearnMetaFile: isSelectAllChecked,
+					shouldShowLedgerLive: isSelectAllChecked,
+					shouldShowStrategies: isSelectAllChecked,
+					shouldShowRisk: isSelectAllChecked,
+					shouldShowRiskScore: isSelectAllChecked,
+					shouldShowDescriptions: isSelectAllChecked,
+					shouldShowAPY: isSelectAllChecked,
+					shouldShowWantTokenDescription: isSelectAllChecked
 				});
 			}} />
 	</label>;
@@ -277,6 +313,7 @@ function Index(): ReactNode {
 							/>
 						</span>
 						{shouldShowAnomaliesCheckbox ? <AnomaliesCheckbox appSettings={appSettings} set_appSettings={set_appSettings} /> : null}
+						<SelectAllCheckbox appSettings={appSettings} set_appSettings={set_appSettings} />
 					</div>
 				</div>
 				<div className={'flex flex-wrap pb-6'}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,26 +66,28 @@ const AnomaliesCheckbox = ({appSettings, set_appSettings}: {
 
 const SelectAllCheckbox = ({appSettings, set_appSettings}: {
 	appSettings: TSettings,
-	set_appSettings: (s: TSettings) => void
+	set_appSettings: React.Dispatch<React.SetStateAction<TSettings>>
 }): ReactElement | null => {
 	useEffect((): void => {
-		const isAllSelected = [
-			appSettings.shouldShowMissingTranslations,
-			appSettings.shouldShowIcons,
-			appSettings.shouldShowPrice,
-			appSettings.shouldShowRetirement,
-			appSettings.shouldShowYearnMetaFile,
-			appSettings.shouldShowLedgerLive,
-			appSettings.shouldShowStrategies,
-			appSettings.shouldShowRisk,
-			appSettings.shouldShowRiskScore,
-			appSettings.shouldShowDescriptions,
-			appSettings.shouldShowAPY,
-			appSettings.shouldShowWantTokenDescription
-		].every(Boolean);
-
-		set_appSettings({...appSettings, shouldShowAllFilters: isAllSelected});
-	}, [appSettings, set_appSettings]);
+		set_appSettings((prev): TSettings => {
+			const isAllSelected = [
+				prev.shouldShowMissingTranslations,
+				prev.shouldShowIcons,
+				prev.shouldShowPrice,
+				prev.shouldShowRetirement,
+				prev.shouldShowYearnMetaFile,
+				prev.shouldShowLedgerLive,
+				prev.shouldShowStrategies,
+				prev.shouldShowRisk,
+				prev.shouldShowRiskScore,
+				prev.shouldShowDescriptions,
+				prev.shouldShowAPY,
+				prev.shouldShowWantTokenDescription
+			].every(Boolean);
+			
+			return ({...prev, shouldShowAllFilters: isAllSelected});
+		});
+	}, [set_appSettings]);
 
 	return <label
 		htmlFor={'checkbox-anomalies'}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -68,6 +68,25 @@ const SelectAllCheckbox = ({appSettings, set_appSettings}: {
 	appSettings: TSettings,
 	set_appSettings: (s: TSettings) => void
 }): ReactElement | null => {
+	useEffect((): void => {
+		const isAllSelected = [
+			appSettings.shouldShowMissingTranslations,
+			appSettings.shouldShowIcons,
+			appSettings.shouldShowPrice,
+			appSettings.shouldShowRetirement,
+			appSettings.shouldShowYearnMetaFile,
+			appSettings.shouldShowLedgerLive,
+			appSettings.shouldShowStrategies,
+			appSettings.shouldShowRisk,
+			appSettings.shouldShowRiskScore,
+			appSettings.shouldShowDescriptions,
+			appSettings.shouldShowAPY,
+			appSettings.shouldShowWantTokenDescription
+		].every(Boolean);
+
+		set_appSettings({...appSettings, shouldShowAllFilters: isAllSelected});
+	}, [appSettings, set_appSettings]);
+
 	return <label
 		htmlFor={'checkbox-anomalies'}
 		className={'flex w-fit cursor-pointer flex-row items-center rounded-lg bg-neutral-200/60 p-2 font-mono text-sm text-neutral-500 transition-colors hover:bg-neutral-200'}>

--- a/types/types.tsx
+++ b/types/types.tsx
@@ -4,6 +4,7 @@ import {TProtocolsData, TStrategiesData, TTokensData, TVaultsData} from './entit
 export type TEntity = 'vaults' | 'tokens' | 'protocols' | 'strategies' | 'partners';
 export type TVersions = 'all' | 'v2' | 'v3' | 'v4';
 export type TSettings = {
+	shouldShowAllFilters: boolean,
 	shouldShowOnlyAnomalies: boolean,
 	shouldShowOnlyEndorsed: boolean,
 	shouldShowMissingTranslations: boolean,


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add a new checkbox to (de)select all filters

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/110

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allow users to quickly select filters. Best use case is when a user wants just one filter, they can click on "Select all", then again and it will deselect all, then they can just select the one they are interested in.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally, checking/unchecking the chexkbox

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot 2023-08-07 at 13 55 27" src="https://github.com/yearn/ySync/assets/78794805/21471fff-4398-4da5-9c28-cd55e5f61eda">

<img width="1582" alt="Screenshot 2023-08-07 at 13 55 31" src="https://github.com/yearn/ySync/assets/78794805/8be96c60-1c48-4d0a-9ab6-bebde41d270b">
