### PR TITLE
feat: Dynamic error percentage

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -306,7 +306,7 @@ function Index(): ReactNode {
 
 					const hasAnomalies = (
 						(appSettings.shouldShowStrategies && vault.strategies.length === 0)
-						|| (appSettings.shouldShowMissingTranslations && !vaultData.missingTranslations)
+						|| (appSettings.shouldShowMissingTranslations && !!vaultData.missingTranslations)
 						|| (appSettings.shouldShowIcons && !vaultData.hasValidIcon)
 						|| (appSettings.shouldShowIcons && !vaultData.hasValidTokenIcon)
 						|| (appSettings.shouldShowPrice && !vaultData.hasValidPrice)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -306,6 +306,7 @@ function Index(): ReactNode {
 
 					const hasAnomalies = (
 						(appSettings.shouldShowStrategies && vault.strategies.length === 0)
+						|| (appSettings.shouldShowMissingTranslations && !vaultData.missingTranslations)
 						|| (appSettings.shouldShowIcons && !vaultData.hasValidIcon)
 						|| (appSettings.shouldShowIcons && !vaultData.hasValidTokenIcon)
 						|| (appSettings.shouldShowPrice && !vaultData.hasValidPrice)
@@ -327,7 +328,7 @@ function Index(): ReactNode {
 		);
 		return _errorCount / (vaults.length || 1) * 100;
 
-	}, [appSettings.shouldShowEntity, appSettings.shouldShowStrategies, appSettings.shouldShowIcons, appSettings.shouldShowPrice, appSettings.shouldShowRetirement, appSettings.shouldShowYearnMetaFile, appSettings.shouldShowLedgerLive, appSettings.shouldShowRisk, appSettings.shouldShowAPY, appSettings.shouldShowWantTokenDescription, appSettings.shouldShowRiskScore, appSettings.shouldShowDescriptions, vaults, tokens, aggregatedData.tokens, aggregatedData.vaults, partners]);
+	}, [appSettings.shouldShowEntity, appSettings.shouldShowStrategies, appSettings.shouldShowMissingTranslations, appSettings.shouldShowIcons, appSettings.shouldShowPrice, appSettings.shouldShowRetirement, appSettings.shouldShowYearnMetaFile, appSettings.shouldShowLedgerLive, appSettings.shouldShowRisk, appSettings.shouldShowAPY, appSettings.shouldShowWantTokenDescription, appSettings.shouldShowRiskScore, appSettings.shouldShowDescriptions, vaults, tokens, aggregatedData.tokens, aggregatedData.vaults, partners]);
 
 	const versions: { [K in TVersions]: { label: string; value: string } } = {
 		all: {label: 'All', value: 'all'},

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -268,23 +268,66 @@ function Index(): ReactNode {
 		const _errorCount = (
 			vaults
 				.filter((vault): boolean => {
+					const vaultData = aggregatedData.vaults[toAddress(vault.address)];
+					if (!vaultData) {
+						return false;
+					}
+
+					const riskScores = (vaultData.strategies ?? []).map((strategy): { strategy: { address: string; name: string; }; sum: number; isValid: boolean } => {
+						const {riskDetails} = strategy?.risk || {};
+						if (!riskDetails) {
+							return {strategy: {address: strategy.address, name: strategy.name}, sum: 0, isValid: false};
+						}
+						const sum = (
+							(riskDetails.TVLImpact || 0)
+							+ (riskDetails.auditScore || 0)
+							+ (riskDetails.codeReviewScore || 0)
+							+ (riskDetails.complexityScore || 0)
+							+ (riskDetails.longevityImpact || 0)
+							+ (riskDetails.protocolSafetyScore || 0)
+							+ (riskDetails.teamKnowledgeScore || 0)
+							+ (riskDetails.testingScore || 0)
+						);
+
+						return {
+							strategy: {
+								address: strategy.address,
+								name: strategy.name
+							},
+							sum,
+							isValid: sum > 0 && sum < 40
+						};
+					});
+
+					const descriptions = (vaultData.strategies ?? []).map((strategy): { strategy: any; isValid: boolean } => ({
+						strategy,
+						isValid: strategy.description !== ''
+					}));
+
 					const hasAnomalies = (
-						vault.strategies.length === 0
-						|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidPrice
-						|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidIcon
-						|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidTokenIcon
-						|| !aggregatedData.vaults[toAddress(vault.address)]?.hasLedgerIntegration
-						|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidStrategiesDescriptions
-						|| !aggregatedData.vaults[toAddress(vault.address)]?.hasValidStrategiesRisk
-						|| !aggregatedData.vaults[toAddress(vault.address)]?.hasYearnMetaFile
-						|| aggregatedData.vaults[toAddress(vault.address)]?.hasErrorAPY);
+						(appSettings.shouldShowStrategies && vault.strategies.length === 0)
+						|| (appSettings.shouldShowIcons && !vaultData.hasValidIcon)
+						|| (appSettings.shouldShowIcons && !vaultData.hasValidTokenIcon)
+						|| (appSettings.shouldShowPrice && !vaultData.hasValidPrice)
+						|| (appSettings.shouldShowRetirement && !vaultData.hasValidRetirement)
+						|| (appSettings.shouldShowYearnMetaFile && !vaultData.hasYearnMetaFile)
+						|| (appSettings.shouldShowLedgerLive && !vaultData.hasLedgerIntegration.deployed)
+						|| (appSettings.shouldShowStrategies && !vaultData.hasValidStrategiesDescriptions) // TODO: check if this is correct
+						|| (appSettings.shouldShowStrategies && !vaultData.hasValidStrategiesRisk) // TODO: check if this is correct
+						|| (appSettings.shouldShowRisk && vaultData.strategies.some((strategy): boolean => (strategy?.risk?.riskGroup || 'Others') === 'Others'))
+						|| (appSettings.shouldShowAPY && vaultData.hasErrorAPY)
+						|| (appSettings.shouldShowAPY && vaultData.hasNewAPY)
+						|| (appSettings.shouldShowWantTokenDescription && !vaultData.token?.description)
+						|| (appSettings.shouldShowRiskScore && riskScores?.some((isValid): boolean => !isValid))
+						|| (appSettings.shouldShowDescriptions && descriptions?.some(({isValid}): boolean => !isValid))
+					);
 					return (hasAnomalies);
 				})
 				.length
 		);
 		return _errorCount / (vaults.length || 1) * 100;
 
-	}, [appSettings.shouldShowEntity, vaults, tokens, aggregatedData.tokens, aggregatedData.vaults, partners]);
+	}, [appSettings.shouldShowEntity, appSettings.shouldShowStrategies, appSettings.shouldShowIcons, appSettings.shouldShowPrice, appSettings.shouldShowRetirement, appSettings.shouldShowYearnMetaFile, appSettings.shouldShowLedgerLive, appSettings.shouldShowRisk, appSettings.shouldShowAPY, appSettings.shouldShowWantTokenDescription, appSettings.shouldShowRiskScore, appSettings.shouldShowDescriptions, vaults, tokens, aggregatedData.tokens, aggregatedData.vaults, partners]);
 
 	const versions: { [K in TVersions]: { label: string; value: string } } = {
 		all: {label: 'All', value: 'all'},


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Only consider the error if that item is selected

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/109

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Easier to see the % of errors for each item(s)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally, you can click on the items you're interested in and observe the error ratio changing accordingly.

## Screenshots (if appropriate):

### No errors

<img width="1582" alt="Screenshot 2023-08-08 at 13 36 34" src="https://github.com/yearn/ySync/assets/78794805/98e0514f-3283-41f3-b812-858393428759">

### 100% errors (translations, don't panic 😅 )

<img width="1582" alt="Screenshot 2023-08-08 at 13 36 25" src="https://github.com/yearn/ySync/assets/78794805/b98f5880-42c3-4db5-8120-35d024731079">

### Some errors

<img width="1582" alt="Screenshot 2023-08-08 at 13 36 31" src="https://github.com/yearn/ySync/assets/78794805/c4fb9c33-cdc0-4d16-aa25-ecd59e00fd22">
