### PR TITLE
refactor: On apy error check if vault is retired or always hidden

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -246,7 +246,7 @@ function VaultEntity({
 	}));
 	const hasDescriptionsAnomaly = descriptions?.some(({isValid}): boolean => !isValid);
 
-	const hasAPYAnomaly = vaultData?.hasErrorAPY || vaultData?.hasNewAPY;
+	const hasAPYAnomaly = !vaultData.details.retired && !vaultData.details.hideAlways && vaultData?.hasErrorAPY || vaultData?.hasNewAPY;
 	const hasWantTokenDescriptionAnomaly = !vaultData?.token?.description;
 
 	const shouldRenderDueToMissingIcon = hasIconAnomaly && vaultSettings.shouldShowIcons;

--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -246,7 +246,7 @@ function VaultEntity({
 	}));
 	const hasDescriptionsAnomaly = descriptions?.some(({isValid}): boolean => !isValid);
 
-	const hasAPYAnomaly = !vaultData?.details?.retired && !vaultData?.details?.hideAlways && vaultData?.hasErrorAPY || vaultData?.hasNewAPY;
+	const hasAPYAnomaly = !vaultData?.details?.retired && !vaultData?.details?.hideAlways && (vaultData?.hasErrorAPY || vaultData?.hasNewAPY);
 	const hasWantTokenDescriptionAnomaly = !vaultData?.token?.description;
 
 	const shouldRenderDueToMissingIcon = hasIconAnomaly && vaultSettings.shouldShowIcons;

--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -246,7 +246,7 @@ function VaultEntity({
 	}));
 	const hasDescriptionsAnomaly = descriptions?.some(({isValid}): boolean => !isValid);
 
-	const hasAPYAnomaly = !vaultData.details.retired && !vaultData.details.hideAlways && vaultData?.hasErrorAPY || vaultData?.hasNewAPY;
+	const hasAPYAnomaly = !vaultData?.details?.retired && !vaultData?.details?.hideAlways && vaultData?.hasErrorAPY || vaultData?.hasNewAPY;
 	const hasWantTokenDescriptionAnomaly = !vaultData?.token?.description;
 
 	const shouldRenderDueToMissingIcon = hasIconAnomaly && vaultSettings.shouldShowIcons;

--- a/contexts/useYearn.tsx
+++ b/contexts/useYearn.tsx
@@ -165,12 +165,9 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasErrorAPY: data.apy.type === 'error',
 					hasNewAPY: data.apy.type === 'new',
 					missingTranslations,
-					token: data?.token,
 					address: toAddress(data.address),
 					name: data.display_name || data.name,
-					icon: data.icon,
-					version: data.version,
-					strategies: data.strategies
+					...data
 				};
 			}
 		}
@@ -205,12 +202,12 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasYearnMetaFile,
 					hasValidRetirement: isRetirementValid(data),
 					missingTranslations: {},
-					token: data?.token,
 					address: toAddress(data.address),
 					name: data?.contractName || '',
 					icon: '',
 					version: 'Unknown',
-					strategies: []
+					strategies: [],
+					...data
 
 				};
 				continue;
@@ -247,12 +244,12 @@ export const YearnContextApp = ({children}: {children: ReactElement}): ReactElem
 					hasYearnMetaFile,
 					hasValidRetirement: isRetirementValid(data),
 					missingTranslations: {},
-					token: data?.token,
 					address: toAddress(data.address),
 					name: data?.contractName || '',
 					icon: '',
 					version: 'Unknown',
-					strategies: []
+					strategies: [],
+					...data
 
 				};
 				continue;

--- a/types/entities.tsx
+++ b/types/entities.tsx
@@ -16,6 +16,10 @@ export type	TVaultData = {
 		incoming?: boolean;
 		deployed?: boolean;
 	};
+	details: {
+		hideAlways: false
+		retired?: boolean;
+	}
 	hasValidStrategiesDescriptions: boolean;
 	hasValidStrategiesTranslations: boolean;
 	hasValidStrategiesRisk: boolean;

--- a/types/entities.tsx
+++ b/types/entities.tsx
@@ -18,7 +18,7 @@ export type	TVaultData = {
 	};
 	details: {
 		hideAlways: false
-		retired?: boolean;
+		retired: boolean;
 	}
 	hasValidStrategiesDescriptions: boolean;
 	hasValidStrategiesTranslations: boolean;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

When searching for APY errors check first if vault details has retired=true or hideAlways=true if either of those are true skip checking for APY since it doesn't matter

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/90

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We don't want old vaults showing an apy error

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally