### PR TITLE
fix: Check validity per strategy

### DIFF
--- a/components/VaultEntity.tsx
+++ b/components/VaultEntity.tsx
@@ -499,12 +499,12 @@ function VaultEntity({
 									key={`${description.strategy.address}_description`}
 									onClick={(): void => onTriggerModalForDescription(description.strategy)}
 									settings={vaultSettings}
-									isValid={!hasDescriptionsAnomaly}
+									isValid={description.isValid}
 									prefix={'Description'}
 									suffix={(
 										<span>
 											{'for strategy '}
-											<a href={`${networks[chainID].explorerBaseURI}/address/${description.strategy.address}`} target={'_blank'} className={`underline ${!hasDescriptionsAnomaly ? '' : 'text-red-900'}`} rel={'noreferrer'}>
+											<a href={`${networks[chainID].explorerBaseURI}/address/${description.strategy.address}`} target={'_blank'} className={`underline ${description.isValid ? '' : 'text-red-900'}`} rel={'noreferrer'}>
 												{description.strategy.name}
 											</a>
 										</span>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

We were marking all strategy descriptions as invalid if some were invalid. We should instead check per strategy if they have a valid description.

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/ySync/issues/117

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Show the correct status for strategy descriptions

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, screenshot below 

## Screenshots (if appropriate):
<img width="1582" alt="Screenshot 2023-08-15 at 10 31 27" src="https://github.com/yearn/ySync/assets/78794805/f4722174-cadf-4390-a40a-cb941698595c">
