### PR TITLE
refactor: Uncheck APY and Legder live by default

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -25,12 +25,12 @@ const defaultSettings: TSettings = {
 	shouldShowPrice: true,
 	shouldShowRetirement: true,
 	shouldShowYearnMetaFile: true,
-	shouldShowLedgerLive: true,
+	shouldShowLedgerLive: false,
 	shouldShowStrategies: true,
 	shouldShowRisk: true,
 	shouldShowRiskScore: true,
 	shouldShowDescriptions: true,
-	shouldShowAPY: true,
+	shouldShowAPY: false,
 	shouldShowWantTokenDescription: true,
 	shouldShowEntity: 'vaults'
 };


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Default the APY and Legder live to `false`

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/ySync/issues/127

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It saves us a few minutes every time we check ySync

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, checkboxes referred above unchecked

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot 2023-10-05 at 10 55 35" src="https://github.com/yearn/ySync/assets/78794805/563166bb-a71b-4958-ad36-606f81da6d77">

